### PR TITLE
feat: 프로필 컴포넌트 리렌더링 구현 #6

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,52 +1,40 @@
-import React, { useState } from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import Main from "@main/Main";
-import ChatList from "@chatList/ChatList";
-import GameList from "@gameList/GameList";
-import ChatRoom from "@chatRoom/ChatRoom";
-import GameRoom from "@gameRoom/GameRoom";
-import Profile from "@leftSide/profile/Profile";
-import RightSide from "@rightSide/RightSide";
-import * as S from "./style";
+import React, { useState } from "react"
+import { BrowserRouter, Routes, Route } from "react-router-dom"
+import Main from "@main/Main"
+import ChatList from "@chatList/ChatList"
+import GameList from "@gameList/GameList"
+import ChatRoom from "@chatRoom/ChatRoom"
+import GameRoom from "@gameRoom/GameRoom"
+import Profile from "@leftSide/profile/Profile"
+import RightSide from "@rightSide/RightSide"
+import * as S from "./style"
 
 function App() {
-  const [profileUser, setProfileUser] = useState(0);
-  const [inPageOf, setInPageOf] = useState<"main" | "chat" | "game">("main");
+  const [profileUser, setProfileUser] = useState(0)
+  const [inPageOf, setInPageOf] = useState<"main" | "chat" | "game">("main")
 
   return (
     <S.AppLayout>
       <S.LeftSideLayout>
-        <Profile user={profileUser} />
+        <Profile userId={profileUser} />
       </S.LeftSideLayout>
       <S.CenterLayout>
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Main setPage={setInPageOf} />} />
-            <Route
-              path="/chat/list"
-              element={<ChatList setPage={setInPageOf} />}
-            />
-            <Route
-              path="/game/list"
-              element={<GameList setPage={setInPageOf} />}
-            />
-            <Route
-              path="/chat/:roomId"
-              element={<ChatRoom setPage={setInPageOf} />}
-            />
-            <Route
-              path="/game/:gameId"
-              element={<GameRoom setPage={setInPageOf} />}
-            />
+            <Route path="/chat/list" element={<ChatList setPage={setInPageOf} />} />
+            <Route path="/game/list" element={<GameList setPage={setInPageOf} />} />
+            <Route path="/chat/:roomId" element={<ChatRoom setPage={setInPageOf} />} />
+            <Route path="/game/:gameId" element={<GameRoom setPage={setInPageOf} />} />
             {/* TODO: 경로 일치하지 않으면 404 NON FOUND 페이지 */}
           </Routes>
         </BrowserRouter>
       </S.CenterLayout>
       <S.RightSideLayout>
-        <RightSide inPageOf={inPageOf} />
+        <RightSide inPageOf={inPageOf} setProfileUser={setProfileUser} />
       </S.RightSideLayout>
     </S.AppLayout>
-  );
+  )
 }
 
-export default App;
+export default App

--- a/src/components/leftSide/profile/Profile.tsx
+++ b/src/components/leftSide/profile/Profile.tsx
@@ -1,10 +1,61 @@
-import React from "react";
-import * as S from "./style";
+import React from "react"
+import * as S from "./style"
 
-export default function Profile(props: { user: number }) {
+export default function Profile(props: { userId: number }) {
+  const tmpUser = [
+    {
+      id: 0,
+      nickname: "숨송",
+      status: "온라인",
+      record: {
+        win: 3,
+        lose: 1,
+      },
+      gameHistory: [
+        {
+          id: 1,
+          player1: "숨송",
+          player2: "아무개",
+          player1score: 4,
+          player2score: 6,
+        },
+      ],
+    },
+    {
+      id: 1,
+      nickname: "아무개",
+      status: "온라인",
+      record: {
+        win: 2,
+        lose: 2,
+      },
+      gameHistory: [
+        {
+          id: 1,
+          player1: "숨송",
+          player2: "아무개",
+          player1score: 4,
+          player2score: 6,
+        },
+      ],
+    },
+    {
+      id: 2,
+      nickname: "아무개개",
+      status: "오프라인",
+      record: {
+        win: 0,
+        lose: 0,
+      },
+      gameHistory: [],
+    },
+  ]
+
+  const user = tmpUser.filter((user) => user.id === props.userId)[0]
+
   return (
     <S.profileLayout>
-      <h3>프로필</h3>
+      <h3>{props.userId === 0 ? "내 프로필" : "친구 프로필"}</h3>
       <S.tmpImg />
       <S.infoWrapper>
         <S.infoLabel>
@@ -15,19 +66,27 @@ export default function Profile(props: { user: number }) {
           히스토리
         </S.infoLabel>
         <S.infoValue>
-          숨송
+          {user.nickname}
           <br />
-          1승 1패
+          {user.record.win}승 {user.record.win}패
           <br />
         </S.infoValue>
       </S.infoWrapper>
-      <S.players>
-        <S.player>숨송</S.player>
-        <S.versus>vs</S.versus>
-        <S.player>아무개</S.player>
-      </S.players>
-      <S.score>3 : 3</S.score>
-      <div>{props.user === 0 ? "내 프로필" : "친구 프로필"}</div>
+      {user.gameHistory &&
+        user.gameHistory.map((game) => {
+          return (
+            <S.historyItem key={game.id}>
+              <S.players>
+                <S.player>{game.player1}</S.player>
+                <S.versus>vs</S.versus>
+                <S.player>{game.player2}</S.player>
+              </S.players>
+              <S.score>
+                {game.player1score} : {game.player2score}
+              </S.score>
+            </S.historyItem>
+          )
+        })}
     </S.profileLayout>
-  );
+  )
 }

--- a/src/components/leftSide/profile/style.tsx
+++ b/src/components/leftSide/profile/style.tsx
@@ -1,11 +1,11 @@
-import styled from "@emotion/styled";
+import styled from "@emotion/styled"
 
 export const profileLayout = styled.div`
   display: flex;
   flex-direction: column;
 
   padding: 10px;
-`;
+`
 
 export const tmpImg = styled.div`
   width: 100px;
@@ -14,36 +14,42 @@ export const tmpImg = styled.div`
   background-color: gray;
 
   margin: 20px auto;
-`;
+`
 
 export const infoWrapper = styled.div`
   display: flex;
-`;
+`
 
 export const infoLabel = styled.span`
   width: 50%;
   line-height: 30px;
-`;
+`
 
 export const infoValue = styled.span`
   line-height: 30px;
-`;
+`
+
+export const historyItem = styled.li`
+  display: flex;
+  flex-direction: column;
+  list-type: none;
+`
 
 export const players = styled.div`
   display: flex;
   justify-content: center;
-`;
+`
 
 export const player = styled.span`
   width: 40;
   text-align: center;
-`;
+`
 
 export const versus = styled.span`
   width: 20%;
   text-align: center;
-`;
+`
 
 export const score = styled.span`
   text-align: center;
-`;
+`

--- a/src/components/rightSide/RightSide.tsx
+++ b/src/components/rightSide/RightSide.tsx
@@ -1,25 +1,26 @@
-import React from "react";
-import UserList from "./userList/UserList";
+import React from "react"
+import UserList from "./userList/UserList"
 
 export default function RightSide(props: {
-  inPageOf: "main" | "chat" | "game",
+  inPageOf: "main" | "chat" | "game"
+  setProfileUser: (userId: number) => void
 }) {
   switch (props.inPageOf) {
     case "main":
       return (
         <>
-          <UserList listOf={"friend"} />
-          <UserList listOf={"dm"} />
+          <UserList listOf={"friend"} setProfileUser={props.setProfileUser} />
+          <UserList listOf={"dm"} setProfileUser={props.setProfileUser} />
         </>
-      );
+      )
     case "chat":
-      return <UserList listOf={"participant"} />;
+      return <UserList listOf={"participant"} setProfileUser={props.setProfileUser} />
     case "game":
       return (
         <>
-          <UserList listOf="player" />
-          <UserList listOf="observer" />
+          <UserList listOf="player" setProfileUser={props.setProfileUser} />
+          <UserList listOf="observer" setProfileUser={props.setProfileUser} />
         </>
-      );
+      )
   }
 }

--- a/src/components/rightSide/userList/UserList.tsx
+++ b/src/components/rightSide/userList/UserList.tsx
@@ -1,20 +1,40 @@
-import React from "react";
-import * as S from "./style";
+import React from "react"
+import * as S from "./style"
 
 export default function UserList(props: {
-  listOf: "friend" | "dm" | "participant" | "player" | "observer";
+  listOf: "friend" | "dm" | "participant" | "player" | "observer"
 }) {
+  const tmpUser = [
+    {
+      id: 1,
+      nickname: "아무개",
+      status: "온라인",
+    },
+    {
+      id: 2,
+      nickname: "아무개개",
+      status: "오프라인",
+    },
+  ]
+
   return (
     <S.userListLayout>
       <h3>{props.listOf}</h3>
-      <S.userWrapper>
-        <S.tmpImg />
-        <span>
-          친구1
-          <br />
-          온라인
-        </span>
-      </S.userWrapper>
+      <S.userList>
+        {/* 유저 클릭 시 프로필 렌더링 */}
+        {tmpUser.map((user) => {
+          return (
+            <S.userItem key={user.id}>
+              <S.tmpImg />
+              <span>
+                {user.nickname}
+                <br />
+                {user.status}
+              </span>
+            </S.userItem>
+          )
+        })}
+      </S.userList>
     </S.userListLayout>
-  );
+  )
 }

--- a/src/components/rightSide/userList/UserList.tsx
+++ b/src/components/rightSide/userList/UserList.tsx
@@ -3,6 +3,7 @@ import * as S from "./style"
 
 export default function UserList(props: {
   listOf: "friend" | "dm" | "participant" | "player" | "observer"
+  setProfileUser: (userId: number) => void
 }) {
   const tmpUser = [
     {
@@ -24,7 +25,7 @@ export default function UserList(props: {
         {/* 유저 클릭 시 프로필 렌더링 */}
         {tmpUser.map((user) => {
           return (
-            <S.userItem key={user.id}>
+            <S.userItem key={user.id} onClick={() => props.setProfileUser(user.id)}>
               <S.tmpImg />
               <span>
                 {user.nickname}

--- a/src/components/rightSide/userList/UserList.tsx
+++ b/src/components/rightSide/userList/UserList.tsx
@@ -22,7 +22,6 @@ export default function UserList(props: {
     <S.userListLayout>
       <h3>{props.listOf}</h3>
       <S.userList>
-        {/* 유저 클릭 시 프로필 렌더링 */}
         {tmpUser.map((user) => {
           return (
             <S.userItem key={user.id} onClick={() => props.setProfileUser(user.id)}>

--- a/src/components/rightSide/userList/style.tsx
+++ b/src/components/rightSide/userList/style.tsx
@@ -1,4 +1,4 @@
-import styled from "@emotion/styled";
+import styled from "@emotion/styled"
 
 export const userListLayout = styled.div`
   display: flex;
@@ -8,17 +8,28 @@ export const userListLayout = styled.div`
   padding: 10px;
 
   background-color: purple;
-`;
+`
 
-export const userWrapper = styled.div`
+export const userList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  margin: 0;
+  padding: 0;
+`
+
+export const userItem = styled.li`
   display: flex;
   gap: 10px;
   align-items: center;
-`;
+
+  list-type: none;
+`
 
 export const tmpImg = styled.div`
   width: 50px;
   height: 50px;
   border-radius: 100%;
   background-color: gray;
-`;
+`

--- a/src/components/rightSide/userList/style.tsx
+++ b/src/components/rightSide/userList/style.tsx
@@ -25,6 +25,7 @@ export const userItem = styled.li`
   align-items: center;
 
   list-type: none;
+  cursor: pointer;
 `
 
 export const tmpImg = styled.div`


### PR DESCRIPTION
## 개요
- 프로필 컴포넌트 리렌더링 구현

## 작업사항
- 오른쪽 유저리스트에 더미 데이터 생성
- 클릭한 유저 아이디에 따라 왼쪽 프로필의 state 설정
- 왼쪽 프로필에 더미 데이터 생성
- 들어오는 유저 아이디에 따라 프로필 정보 변경

## 변경로직

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
