### PR TITLE
feat: 프로필 영역 완성 api 업데이트, 스타일 #22

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,12 +22,12 @@ const Unauth = loadable(() => {
   return import("@unauth/Unauth");
 });
 
+const initialState = {
+  isSignIn: false,
+};
+
 function App() {
-  const [authState, authDispatch] = useReducer(authReducer, {
-    isSignIn: false,
-    username: null,
-    token: null,
-  });
+  const [authState, authDispatch] = useReducer(authReducer, initialState);
 
   const authContext = { authState, authDispatch };
   // context 잘 설정되어 있는지 확인용 로그

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { StrictMode, useEffect, useReducer } from "react";
+import { useEffect, useReducer } from "react";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthContext } from "@hooks/AuthContext";
@@ -40,14 +40,12 @@ function App() {
   }, [authState]);
 
   return (
-    <StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <AuthContext.Provider value={authContext}>
-          <main>{authState.isSignIn ? <Auth /> : <Unauth />}</main>;
-        </AuthContext.Provider>
-        <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />
-      </QueryClientProvider>
-    </StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <AuthContext.Provider value={authContext}>
+        <main style={{ height: "100%" }}>{authState.isSignIn ? <Auth /> : <Unauth />}</main>;
+      </AuthContext.Provider>
+      <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />
+    </QueryClientProvider>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ function App() {
     axios.defaults.baseURL = "http://localhost:81";
     if (authState.token)
       axios.defaults.headers.common["Authorization"] = `Bearer ${authState.token}`;
-  }, [authContext]);
+  }, [authState]);
 
   return (
     <StrictMode>

--- a/src/components/leftSide/profile/Profile.tsx
+++ b/src/components/leftSide/profile/Profile.tsx
@@ -2,62 +2,11 @@ import { useQuery } from "@tanstack/react-query";
 import { getProfile } from "api/user";
 import { ProfileData } from "./ProfileData";
 
-export default function Profile(props: { userId?: number; username: string }) {
-  // 임시 데이터, 쿼리 연동되면 삭제
-  const tmpUser = [
-    {
-      id: 0,
-      nickname: "숨송",
-      status: "온라인",
-      record: {
-        win: 3,
-        lose: 1,
-      },
-      gameHistory: [
-        {
-          id: 1,
-          player1: "숨송",
-          player2: "아무개",
-          player1score: 4,
-          player2score: 6,
-        },
-      ],
-    },
-    {
-      id: 1,
-      nickname: "아무개",
-      status: "온라인",
-      record: {
-        win: 2,
-        lose: 2,
-      },
-      gameHistory: [
-        {
-          id: 1,
-          player1: "숨송",
-          player2: "아무개",
-          player1score: 4,
-          player2score: 6,
-        },
-      ],
-    },
-    {
-      id: 2,
-      nickname: "아무개개",
-      status: "오프라인",
-      record: {
-        win: 0,
-        lose: 0,
-      },
-      gameHistory: [],
-    },
-  ];
-  const user = tmpUser.filter((user) => user.id === props.userId)[0];
-
+export default function Profile(props: { username?: string }) {
   const profileQuery = useQuery({
     queryKey: ["profile", `${props.username}`],
     queryFn: () => {
-      return getProfile(props.username);
+      if (props.username) return getProfile(props.username);
     },
   });
 

--- a/src/components/leftSide/profile/ProfileData.tsx
+++ b/src/components/leftSide/profile/ProfileData.tsx
@@ -1,4 +1,6 @@
+import { useContext } from "react";
 import * as S from "./style";
+import { AuthContext } from "@hooks/AuthContext";
 
 interface userProps {
   user?: {
@@ -24,6 +26,14 @@ interface userProps {
 export function ProfileData(props: userProps) {
   let user;
   if (props) user = props.user;
+
+  const dispatch = useContext(AuthContext)?.authDispatch;
+  const handleLogout = () => {
+    if (dispatch)
+      dispatch({
+        type: "signOut",
+      });
+  };
 
   return (
     <S.ProfileLayout>
@@ -67,6 +77,9 @@ export function ProfileData(props: userProps) {
             </S.HistoryItem>
           );
         })}
+      {user && user.relation === "myself" && <button onClick={handleLogout}>로그아웃</button>}
+      {user && user.relation === "friend" && <button>친구 삭제</button>}
+      {user && user.relation === "others" && <button>친구 추가</button>}
     </S.ProfileLayout>
   );
 }

--- a/src/components/leftSide/profile/ProfileData.tsx
+++ b/src/components/leftSide/profile/ProfileData.tsx
@@ -37,7 +37,7 @@ export function ProfileData(props: userProps) {
 
   return (
     <S.ProfileLayout>
-      <h3>프로필</h3>
+      <S.Title>프로필</S.Title>
       {/* 로딩중 기본 이미지 삽입 */}
       <S.TmpImg />
       <S.InfoWrapper>
@@ -47,8 +47,6 @@ export function ProfileData(props: userProps) {
           레이팅
           <br />
           전적
-          <br />
-          히스토리
         </S.InfoLabel>
         <S.InfoValue>
           {user && user.username}
@@ -56,30 +54,34 @@ export function ProfileData(props: userProps) {
           {user && user.rating}
           <br />
           {user && `${user.win}승 ${user.lose}패`}
-          <br />
         </S.InfoValue>
       </S.InfoWrapper>
-      {user &&
-        user.gameHistory.map((game) => {
-          return (
-            <S.HistoryItem key={game.uniqueId}>
-              <S.Score>
-                {game.type === "rank" ? "경쟁" : game.type === "normal" ? "일반" : "아케이드"}전
-              </S.Score>
-              <S.Players>
-                <S.Player>{game.red}</S.Player>
-                <S.Versus>vs</S.Versus>
-                <S.Player>{game.blue}</S.Player>
-              </S.Players>
-              <S.Score>
-                {game.redScore} : {game.blueScore}
-              </S.Score>
-            </S.HistoryItem>
-          );
-        })}
-      {user && user.relation === "myself" && <button onClick={handleLogout}>로그아웃</button>}
-      {user && user.relation === "friend" && <button>친구 삭제</button>}
-      {user && user.relation === "others" && <button>친구 추가</button>}
+      <S.InfoLabel>히스토리</S.InfoLabel>
+      <S.HistoryList>
+        {user &&
+          user.gameHistory.map((game) => {
+            return (
+              <S.HistoryItem key={game.uniqueId}>
+                <S.Score>
+                  {game.type === "rank" ? "경쟁" : game.type === "normal" ? "일반" : "아케이드"}전
+                </S.Score>
+                <S.Players>
+                  <S.Player>{game.red}</S.Player>
+                  <S.Versus>vs</S.Versus>
+                  <S.Player>{game.blue}</S.Player>
+                </S.Players>
+                <S.Score>
+                  {game.redScore} : {game.blueScore}
+                </S.Score>
+              </S.HistoryItem>
+            );
+          })}
+      </S.HistoryList>
+      <S.ButtonBox>
+        {user && user.relation === "myself" && <S.Button onClick={handleLogout}>로그아웃</S.Button>}
+        {user && user.relation === "friend" && <S.Button>친구 삭제</S.Button>}
+        {user && user.relation === "others" && <S.Button>친구 추가</S.Button>}
+      </S.ButtonBox>
     </S.ProfileLayout>
   );
 }

--- a/src/components/leftSide/profile/ProfileData.tsx
+++ b/src/components/leftSide/profile/ProfileData.tsx
@@ -6,9 +6,10 @@ interface userProps {
     rating: number;
     win: number;
     lose: number;
+    relation: "myself" | "friend" | "others";
     gameHistory: [
       {
-        id: number;
+        uniqueId: number;
         red: string;
         blue: string;
         redScore: number;
@@ -33,22 +34,28 @@ export function ProfileData(props: userProps) {
         <S.InfoLabel>
           닉네임
           <br />
+          레이팅
+          <br />
           전적
           <br />
           히스토리
         </S.InfoLabel>
         <S.InfoValue>
-          {user ? user.username : ""}
+          {user && user.username}
           <br />
-          {user ? `${user.win}승 ${user.lose}패` : ""}
+          {user && user.rating}
+          <br />
+          {user && `${user.win}승 ${user.lose}패`}
           <br />
         </S.InfoValue>
       </S.InfoWrapper>
       {user &&
         user.gameHistory.map((game) => {
           return (
-            <S.HistoryItem key={game.id}>
-              <S.Score>{game.type === "rank" ? "경쟁" : "일반"}전</S.Score>
+            <S.HistoryItem key={game.uniqueId}>
+              <S.Score>
+                {game.type === "rank" ? "경쟁" : game.type === "normal" ? "일반" : "아케이드"}전
+              </S.Score>
               <S.Players>
                 <S.Player>{game.red}</S.Player>
                 <S.Versus>vs</S.Versus>

--- a/src/components/leftSide/profile/style.tsx
+++ b/src/components/leftSide/profile/style.tsx
@@ -1,11 +1,23 @@
 import styled from "@emotion/styled";
+import * as font from "@style/font";
+import * as button from "@style/button";
 
 export const ProfileLayout = styled.div`
   display: flex;
   flex-direction: column;
+  max-height: 100vh;
 
   padding: 10px;
 `;
+
+export const Title = styled.h2`
+  ${font.titleBold};
+  margin-bottom: 0;
+`;
+
+/*
+ *      Profile Item
+ */
 
 export const TmpImg = styled.div`
   width: 100px;
@@ -21,12 +33,23 @@ export const InfoWrapper = styled.div`
 `;
 
 export const InfoLabel = styled.span`
-  width: 50%;
+  width: 80px;
+  ${font.bodyBold}
   line-height: 30px;
 `;
 
 export const InfoValue = styled.span`
+  ${font.body}
   line-height: 30px;
+`;
+
+/*
+ *      Game History
+ */
+
+export const HistoryList = styled.ul`
+  height: 400px;
+  overflow: auto;
 `;
 
 export const HistoryItem = styled.li`
@@ -52,4 +75,21 @@ export const Versus = styled.span`
 
 export const Score = styled.span`
   text-align: center;
+`;
+
+/*
+ *      Profile Button
+ */
+
+export const ButtonBox = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  margin: 30px 0;
+`;
+
+export const Button = styled.button`
+  ${button.basicColor}
+  width: 70px;
+  height: 25px;
 `;

--- a/src/components/rightSide/userList/UserList.tsx
+++ b/src/components/rightSide/userList/UserList.tsx
@@ -1,38 +1,39 @@
+import { useQuery } from "@tanstack/react-query";
+import { getProfile } from "@api/user";
 import * as S from "./style";
 
 export default function UserList(props: {
   listOf: "friend" | "dm" | "participant" | "player" | "observer";
   setProfileUser: (userId: string) => void;
 }) {
-  const tmpUser = [
-    {
-      id: 1,
-      nickname: "아무개",
-      status: "온라인",
+  // 테스트할 때는 회원가입된 다른 유저의 username을 아무개 대신 넣어주세요!
+  // 임시 쿼리. 친구 리스트 불러오는 api 필요
+  const profileQuery = useQuery({
+    queryKey: ["profile", "아무개"],
+    queryFn: () => {
+      return getProfile("아무개");
     },
-    {
-      id: 2,
-      nickname: "아무개개",
-      status: "오프라인",
-    },
-  ];
+  });
+
+  if (profileQuery.isLoading) return <S.UserListLayout></S.UserListLayout>;
+  if (profileQuery.isError) console.log(profileQuery.error);
 
   return (
     <S.UserListLayout>
       <h3>{props.listOf}</h3>
       <S.UserList>
-        {tmpUser.map((user) => {
-          return (
-            <S.UserItem key={user.id} onClick={() => props.setProfileUser(user.nickname)}>
-              <S.TmpImg />
-              <span>
-                {user.nickname}
-                <br />
-                {user.status}
-              </span>
-            </S.UserItem>
-          );
-        })}
+        {/* {tmpUser.map((user) => { */}
+        {/* return ( */}
+        <S.UserItem key={1} onClick={() => props.setProfileUser(profileQuery?.data.username)}>
+          <S.TmpImg />
+          <span>
+            {profileQuery?.data?.username}
+            <br />
+            {profileQuery?.data?.status}
+          </span>
+        </S.UserItem>
+        {/* ); */}
+        {/* })} */}
       </S.UserList>
     </S.UserListLayout>
   );

--- a/src/hooks/authReducer.ts
+++ b/src/hooks/authReducer.ts
@@ -1,10 +1,14 @@
 export interface AuthState {
   isSignIn: boolean;
-  username: string | null;
-  token: string | null;
+  username?: string;
+  token?: string;
 }
 
-export type Action = { type: "signIn"; username: string; token: string } | { type: "signOut" };
+export interface Action {
+  type: "signIn" | "signOut";
+  username?: string;
+  token?: string;
+}
 
 export default function authReducer(authState: AuthState, action: Action) {
   switch (action.type) {
@@ -17,8 +21,6 @@ export default function authReducer(authState: AuthState, action: Action) {
     case "signOut":
       return {
         isSignIn: false,
-        username: null,
-        token: null,
       };
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,10 @@
 @import url("https://fonts.googleapis.com/css2?family=Gothic+A1&display=swap");
 
-html {
+html,
+#root {
   font-size: 62.5%;
+  height: 100vh;
+  margin: 0;
 }
 
 body {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,4 +3,8 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(<App />);
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { AuthContext } from "@hooks/AuthContext";
 import Main from "@page/main/Main";
 import ChatList from "@page/chatList/ChatList";
 import GameList from "@page/gameList/GameList";
@@ -11,7 +12,8 @@ import RightSide from "@rightSide/RightSide";
 import * as S from "./style";
 
 function Auth() {
-  const [profileUser, setProfileUser] = useState("sumsong");
+  const authState = useContext(AuthContext)?.authState;
+  const [profileUser, setProfileUser] = useState(authState?.username);
   const [inPageOf, setInPageOf] = useState<"main" | "chat" | "game">("main");
 
   return (

--- a/src/pages/auth/main/style.tsx
+++ b/src/pages/auth/main/style.tsx
@@ -17,8 +17,7 @@ export const H1 = styled.h1`
 `;
 
 export const TextBold = styled.p`
-  ${font.body};
-  font-weight: 600;
+  ${font.bodyBold};
 `;
 
 export const TextBox = styled.div`
@@ -32,8 +31,9 @@ export const TextBox = styled.div`
 
 export const Text = styled.span`
   display: inline;
-  ${font.body};
   margin: 5px;
+
+  ${font.body};
   ${(props: { featured?: boolean }) => {
     return props.featured ? `color: ${blue}; font-weight: 600;` : "";
   }}

--- a/src/pages/auth/style.tsx
+++ b/src/pages/auth/style.tsx
@@ -11,7 +11,7 @@ export const LeftSideLayout = styled.div`
   height: 100%;
   width: 20%;
 
-  background-color: green;
+  border-right: 0.5px solid;
 `;
 
 export const CenterLayout = styled.div`

--- a/src/style/font.tsx
+++ b/src/style/font.tsx
@@ -4,33 +4,38 @@ export const body = `
   font-weight: 400;
   font-size: 1.3rem;
   line-height: 1.7rem;
-`
+`;
 
 export const bodyBold = `
   ${body}
   font-weight: 600;
-`
+`;
 
 export const title = `
   ${body}
   font-size: 2.0rem;
   line-height: 2.4rem;
-`
+`;
+
+export const titleBold = `
+  ${title}
+  font-weight: 600;
+`;
 
 export const h1 = `
   ${bodyBold}
   font-size: 3.0rem;
   line-height: 3.4rem;
-`
+`;
 
 export const inBtn = `
   ${body}
   font-size: 1.0rem;
   line-height: 1.0rem;
-`
+`;
 
 export const footer = `
   ${body}
   font-size: 1.0rem;
   line-height: 1.4rem;
-`
+`;


### PR DESCRIPTION
## 개요
- 프로필 영역 완성 api 업데이트, 스타일

## 작업사항
- 프로필에서 전역 username으로 쿼리 호출
- 프로필 쿼리 데이터로 렌더링
- 프로필 관계 확인하여 버튼 구현
- 프로필 스타일 구현
- 친구 리스트 더미 데이터 생성해서 버튼 렌더링 테스트

## 변경로직
- 더미데이터 일부 프로필 쿼리로 실제 api 연동

## 코멘트
- 오른쪽 친구 리스트에 테스트 데이터로 "아무개" 넣어두었습니다.
  실제 가입한 유저네임 넣어서 테스트 하면 됩니다!
  본인 프로필일 때 로그아웃, 해당 유저 클릭했을 때 [친구 추가] 버튼 뜨면 됩니다~!
- 테스트 관련 안내는 커밋메시지 및 해당 코드 주석 참고하세요~~~
- [내 프로필] 같은 버튼을 만들어서 다른 화면에서도 내 프로필 볼 수 있게끔 해야할듯?
  지금은 임시로 만든거긴 한데, 계속 거기에 로그아웃 버튼을 넣는다면요!

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
