### PR TITLE
fix: 왼쪽 프로필에서 로그아웃 시 페이지 이동 불가 #33

### DIFF
--- a/src/components/leftSide/profile/ProfileData.tsx
+++ b/src/components/leftSide/profile/ProfileData.tsx
@@ -3,6 +3,7 @@ import * as S from "./style";
 import { distroyAuth } from "userAuth";
 import { AuthContext } from "@hooks/AuthContext";
 import { disconnectSocket } from "socket/socket";
+import { Navigate, useNavigate } from "react-router-dom";
 
 interface userProps {
   user?: {
@@ -29,6 +30,7 @@ export function ProfileData(props: userProps) {
   let user;
   if (props) user = props.user;
   const setSigned = useContext(AuthContext);
+  const navigate = useNavigate();
 
   return (
     <S.ProfileLayout>
@@ -79,6 +81,7 @@ export function ProfileData(props: userProps) {
             distroyAuth();
             disconnectSocket();
             if (setSigned) setSigned(false);
+            navigate("/");
           }}
         >
           로그아웃

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,11 @@
+import * as S from './style'
+
+function NotFound() {
+  return (
+    <S.NotFoundLayout>
+      <h2>Not Found Page</h2>
+    </S.NotFoundLayout>
+  )
+}
+
+export default NotFound

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -46,11 +46,11 @@ function Auth() {
 
   return (
     <S.AppLayout>
-      <S.LeftSideLayout>
-        <Profile username={profileUser} />
-      </S.LeftSideLayout>
-      <S.CenterLayout>
-        <BrowserRouter>
+      <BrowserRouter>
+        <S.LeftSideLayout>
+          <Profile username={profileUser} />
+        </S.LeftSideLayout>
+        <S.CenterLayout>
           <ListTabBar />
           <Routes>
             <Route path="/" element={<Main setPage={setInPageOf} />} />
@@ -60,11 +60,11 @@ function Auth() {
             <Route path="/game/:gameId" element={<GameRoom setPage={setInPageOf} />} />
             {/* TODO: 경로 일치하지 않으면 404 NON FOUND 페이지 */}
           </Routes>
-        </BrowserRouter>
-      </S.CenterLayout>
-      <S.RightSideLayout>
-        <RightSide inPageOf={inPageOf} setProfileUser={setProfileUser} />
-      </S.RightSideLayout>
+        </S.CenterLayout>
+        <S.RightSideLayout>
+          <RightSide inPageOf={inPageOf} setProfileUser={setProfileUser} />
+        </S.RightSideLayout>
+      </BrowserRouter>
     </S.AppLayout>
   );
 }

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -8,6 +8,7 @@ import ListTabBar from "@centerHeader/ListTabBar";
 import RightSide from "@rightSide/RightSide";
 import * as S from "./style";
 import loadable from "@loadable/component";
+import NotFound from "pages/NotFound";
 
 const ChatList = loadable(() => {
   return import("@page/chat/chatList/ChatList");
@@ -58,6 +59,7 @@ function Auth() {
             <Route path="/game/list" element={<GameList setPage={setInPageOf} />} />
             <Route path="/chat/:roomId" element={<ChatRoom setPage={setInPageOf} />} />
             <Route path="/game/:gameId" element={<GameRoom setPage={setInPageOf} />} />
+            <Route path={"*"} element={<NotFound />} />
             {/* TODO: 경로 일치하지 않으면 404 NON FOUND 페이지 */}
           </Routes>
         </S.CenterLayout>

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -60,7 +60,6 @@ function Auth() {
             <Route path="/chat/:roomId" element={<ChatRoom setPage={setInPageOf} />} />
             <Route path="/game/:gameId" element={<GameRoom setPage={setInPageOf} />} />
             <Route path={"*"} element={<NotFound />} />
-            {/* TODO: 경로 일치하지 않으면 404 NON FOUND 페이지 */}
           </Routes>
         </S.CenterLayout>
         <S.RightSideLayout>

--- a/src/pages/style.tsx
+++ b/src/pages/style.tsx
@@ -1,0 +1,14 @@
+import styled from "@emotion/styled";
+
+export const NotFoundLayout = styled.div`
+  position: relative;
+  margin: auto;
+  max-width: 400px;
+  width: 100%;
+  text-align: center;
+  background: white;
+  box-shadow: 0 1px 3px 1px rgba(0,0,0,.08);
+  font-size: 14px;
+  border-radius: 20px;
+  padding: 24px;
+`;

--- a/src/pages/unauth/Unauth.tsx
+++ b/src/pages/unauth/Unauth.tsx
@@ -11,7 +11,7 @@ function Unauth() {
         <Routes>
           <Route path="/" element={<SignIn />} />
           <Route path="/signup" element={<SignUp />} />
-          <Route path={"*"} element={<NotFound />} />
+          <Route path="/*" element={<NotFound />} />
           {/* TODO: 경로 일치하지 않으면 404 NON FOUND 페이지 */}
         </Routes>
       </BrowserRouter>

--- a/src/pages/unauth/Unauth.tsx
+++ b/src/pages/unauth/Unauth.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import SignIn from "@unauth/signIn/SignIn";
 import SignUp from "@unauth/signUp/SignUp";
+import NotFound from "pages/NotFound";
 import * as S from "./style";
 
 function Unauth() {
@@ -10,6 +11,7 @@ function Unauth() {
         <Routes>
           <Route path="/" element={<SignIn />} />
           <Route path="/signup" element={<SignUp />} />
+          <Route path={"*"} element={<NotFound />} />
           {/* TODO: 경로 일치하지 않으면 404 NON FOUND 페이지 */}
         </Routes>
       </BrowserRouter>


### PR DESCRIPTION
## 개요
- 왼쪽 프로필에서 로그아웃 페이지 이동 불가
- 접근 불가능한 라우터 처리
## 작업사항
- `BrowserRouter` 위치 조정, 로그아웃 onClick 이벤트에 navigate 추가
- 존재하지 않는 라우터 NotFound 처리
## 변경로직

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
