### PR TITLE
fix: react query 쿼리 키 통일 #48

### DIFF
--- a/src/components/leftSide/profile/ProfileData.tsx
+++ b/src/components/leftSide/profile/ProfileData.tsx
@@ -56,6 +56,8 @@ export function ProfileData(props: userProps) {
       <S.InfoLabel>히스토리</S.InfoLabel>
       <S.HistoryList>
         {user &&
+          user.gameHistory &&
+          // gameHistory 준비중
           user.gameHistory.map((game) => {
             return (
               <S.HistoryItem key={game.uniqueId}>

--- a/src/components/rightSide/MyProfile.tsx
+++ b/src/components/rightSide/MyProfile.tsx
@@ -6,7 +6,7 @@ import * as S from "./style";
 export default function MyProfile(props: { setProfileUser: (userId: string) => void }) {
   const username = getUsername();
   const profileQuery = useQuery({
-    queryKey: ["user", username],
+    queryKey: ["profile", username],
     queryFn: () => {
       return getProfile(username);
     },
@@ -16,12 +16,12 @@ export default function MyProfile(props: { setProfileUser: (userId: string) => v
 
   return (
     <S.MyProfileLayout>
-      <S.UserItem onClick={() => props.setProfileUser(profileQuery?.data.username)}>
+      <S.UserItem onClick={() => props.setProfileUser(profileQuery.data?.username)}>
         <S.TmpImg />
         <span>
-          {profileQuery?.data?.username}
+          {profileQuery.data?.username}
           <br />
-          {profileQuery?.data?.status}
+          {profileQuery.data?.status}
         </span>
       </S.UserItem>
     </S.MyProfileLayout>

--- a/src/components/rightSide/MyProfile.tsx
+++ b/src/components/rightSide/MyProfile.tsx
@@ -21,7 +21,7 @@ export default function MyProfile(props: { setProfileUser: (userId: string) => v
         <span>
           {profileQuery.data?.username}
           <br />
-          {profileQuery.data?.status}
+          온라인
         </span>
       </S.UserItem>
     </S.MyProfileLayout>

--- a/src/components/rightSide/MyProfile.tsx
+++ b/src/components/rightSide/MyProfile.tsx
@@ -21,7 +21,7 @@ export default function MyProfile(props: { setProfileUser: (userId: string) => v
         <span>
           {profileQuery.data?.username}
           <br />
-          온라인
+          🔵 온라인
         </span>
       </S.UserItem>
     </S.MyProfileLayout>

--- a/src/components/rightSide/UserList.tsx
+++ b/src/components/rightSide/UserList.tsx
@@ -29,7 +29,7 @@ export default function UserList(props: {
           <span>
             {profileQuery?.data?.username}
             <br />
-            {profileQuery?.data?.status}
+            {profileQuery?.data?.status === "login" ? "🔵 온라인" : "⚫️ 오프라인"}
           </span>
         </S.UserItem>
         {/* ); */}


### PR DESCRIPTION
## 개요
프로필에 대한 쿼리 키 일부는 profile, 일부는 user로 되어 있음

## 작업사항
- 프로필에 대한 리액트쿼리 키 통일 (모두 profile)
- gameHistory 있는 경우 렌더링 조건 추가
- 내 프로필 언제나 온라인 (status를 실시간으로 받으려면 리패칭이 필요하나, 내 프로필은 언제나 온라인인 경우이므로!)
- login -> 온라인 / logout -> 오프라인 으로 변경

## Etc
쿼리키 통일 시키려고 판 이슈인데 이것저것 추가한거라..
login/logout 외 다른 status가 추가된다면 그때 수정!

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
