### PR TITLE
fix: user 데이터의 relation에 대한 조건문 오류 수정 #50

### DIFF
--- a/src/components/leftSide/profile/ProfileData.tsx
+++ b/src/components/leftSide/profile/ProfileData.tsx
@@ -77,17 +77,18 @@ export function ProfileData(props: userProps) {
           })}
       </S.HistoryList>
       <S.ButtonBox>
-        {!user || user.relation === "myself"}
-        <S.Button
-          onClick={() => {
-            distroyAuth();
-            disconnectSocket();
-            if (setSigned) setSigned(false);
-            navigate("/");
-          }}
-        >
-          로그아웃
-        </S.Button>
+        {(!user || user.relation === "myself") && (
+          <S.Button
+            onClick={() => {
+              distroyAuth();
+              disconnectSocket();
+              if (setSigned) setSigned(false);
+              navigate("/");
+            }}
+          >
+            로그아웃
+          </S.Button>
+        )}
         {user && user.relation === "friend" && <S.Button>친구 삭제</S.Button>}
         {user && user.relation === "others" && <S.Button>친구 추가</S.Button>}
       </S.ButtonBox>


### PR DESCRIPTION
## 개요
- 원래 본인 프로필만 로그아웃 버튼, 나머지는 관계에 따라 친구 추가/삭제 버튼을 띄우려고 했는데 로그아웃 버튼이 어디서든 보임

## 작업사항
- user 데이터의 `relation`에 대한 조건문 오류 수정

## 변경로직
- 로그아웃 버튼은 본인 프로필에서만 보이게 됨

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
