### PR TITLE
feat: 채팅방 내의 유저 목록 업데이트 #43

### DIFF
--- a/src/components/rightSide/MyProfile.tsx
+++ b/src/components/rightSide/MyProfile.tsx
@@ -1,9 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { getProfile } from "@api/user";
 import { getUsername } from "userAuth";
+import { useContext } from "react";
+import { ProfileContext } from "@hooks/ProfileContext";
 import * as S from "./style";
 
-export default function MyProfile(props: { setProfileUser: (userId: string) => void }) {
+export default function MyProfile() {
   const username = getUsername();
   const profileQuery = useQuery({
     queryKey: ["profile", username],
@@ -11,12 +13,17 @@ export default function MyProfile(props: { setProfileUser: (userId: string) => v
       return getProfile(username);
     },
   });
+  const setProfileUser = useContext(ProfileContext);
 
   if (profileQuery.isLoading) return <S.UserItem />;
 
   return (
     <S.MyProfileLayout>
-      <S.UserItem onClick={() => props.setProfileUser(profileQuery.data?.username)}>
+      <S.UserItem
+        onClick={() => {
+          setProfileUser && setProfileUser(profileQuery.data?.username);
+        }}
+      >
         <S.TmpImg />
         <span>
           {profileQuery.data?.username}

--- a/src/components/rightSide/MyProfile.tsx
+++ b/src/components/rightSide/MyProfile.tsx
@@ -1,8 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { getProfile } from "@api/user";
 import { getUsername } from "userAuth";
-import { useContext } from "react";
-import { ProfileContext } from "@hooks/ProfileContext";
+import UserInfo from "./UserInfo";
 import * as S from "./style";
 
 export default function MyProfile() {
@@ -13,23 +12,13 @@ export default function MyProfile() {
       return getProfile(username);
     },
   });
-  const setProfileUser = useContext(ProfileContext);
 
   if (profileQuery.isLoading) return <S.UserItem />;
 
   return (
     <S.MyProfileLayout>
-      <S.UserItem
-        onClick={() => {
-          setProfileUser && setProfileUser(profileQuery.data?.username);
-        }}
-      >
-        <S.TmpImg />
-        <span>
-          {profileQuery.data?.username}
-          <br />
-          🔵 온라인
-        </span>
+      <S.UserItem>
+        <UserInfo username={profileQuery?.data?.username} subLine="🔵 온라인" />
       </S.UserItem>
     </S.MyProfileLayout>
   );

--- a/src/components/rightSide/OtherUserList.tsx
+++ b/src/components/rightSide/OtherUserList.tsx
@@ -1,3 +1,4 @@
+import { useLocation } from "react-router-dom";
 import { ChatUserListType } from "socket/chat";
 import UserList from "./UserList";
 
@@ -6,6 +7,12 @@ export default function OtherUserList(props: {
   setProfileUser: (userId: string) => void;
   chatUsers: ChatUserListType | null;
 }) {
+  const path = useLocation().pathname;
+  let match;
+  let roomId: number;
+  if (props.inPageOf !== "main") match = path.match(/\/\w+\/(\d+)/);
+  if (match && match !== undefined) roomId = Number(match[1]);
+
   switch (props.inPageOf) {
     case "main":
       return (

--- a/src/components/rightSide/OtherUserList.tsx
+++ b/src/components/rightSide/OtherUserList.tsx
@@ -30,6 +30,7 @@ export default function OtherUserList(props: { chatUsers: ChatUserListType | nul
       return (
         <>
           <UserList listOf={"participant"} chatUserList={props.chatUsers} />
+          {/* TODO: 방장과 admin인지 확인 후 노출 */}
           <UserList listOf={"banned"} chatUserList={props.chatUsers} />
         </>
       );

--- a/src/components/rightSide/OtherUserList.tsx
+++ b/src/components/rightSide/OtherUserList.tsx
@@ -2,17 +2,23 @@ import { useLocation } from "react-router-dom";
 import { ChatUserListType } from "socket/chat";
 import UserList from "./UserList";
 
-export default function OtherUserList(props: {
-  inPageOf: "main" | "chat" | "game";
-  chatUsers: ChatUserListType | null;
-}) {
+export default function OtherUserList(props: { chatUsers: ChatUserListType | null }) {
   const path = useLocation().pathname;
-  let match;
+  let page: "main" | "chat" | "game" = "main";
   let roomId: number;
-  if (props.inPageOf !== "main") match = path.match(/\/\w+\/(\d+)/);
-  if (match && match !== undefined) roomId = Number(match[1]);
+  let match;
 
-  switch (props.inPageOf) {
+  if ((match = path.match(/\/$/)) || (match = path.match(/\/(game|chat)\/list/))) {
+    page = "main";
+  } else if ((match = path.match(/\/chat\/(\d+)/))) {
+    page = "chat";
+    roomId = Number(match[1]);
+  } else if ((match = path.match(/\/game\/(\d+)/))) {
+    page = "game";
+    roomId = Number(match[1]);
+  }
+
+  switch (page) {
     case "main":
       return (
         <>

--- a/src/components/rightSide/OtherUserList.tsx
+++ b/src/components/rightSide/OtherUserList.tsx
@@ -4,7 +4,7 @@ import UserList from "./UserList";
 export default function OtherUserList(props: {
   inPageOf: "main" | "chat" | "game";
   setProfileUser: (userId: string) => void;
-  chatUsers: ChatUserListType | null
+  chatUsers: ChatUserListType | null;
 }) {
   switch (props.inPageOf) {
     case "main":
@@ -15,7 +15,20 @@ export default function OtherUserList(props: {
         </>
       );
     case "chat":
-      return <UserList listOf={"participant"} setProfileUser={props.setProfileUser} chatUserList={props.chatUsers}/>;
+      return (
+        <>
+          <UserList
+            listOf={"participant"}
+            setProfileUser={props.setProfileUser}
+            chatUserList={props.chatUsers}
+          />
+          <UserList
+            listOf={"banned"}
+            setProfileUser={props.setProfileUser}
+            chatUserList={props.chatUsers}
+          />
+        </>
+      );
     case "game":
       return (
         <>

--- a/src/components/rightSide/OtherUserList.tsx
+++ b/src/components/rightSide/OtherUserList.tsx
@@ -4,7 +4,6 @@ import UserList from "./UserList";
 
 export default function OtherUserList(props: {
   inPageOf: "main" | "chat" | "game";
-  setProfileUser: (userId: string) => void;
   chatUsers: ChatUserListType | null;
 }) {
   const path = useLocation().pathname;
@@ -17,30 +16,22 @@ export default function OtherUserList(props: {
     case "main":
       return (
         <>
-          <UserList listOf={"friend"} setProfileUser={props.setProfileUser} />
-          <UserList listOf={"dm"} setProfileUser={props.setProfileUser} />
+          <UserList listOf={"friend"} />
+          <UserList listOf={"dm"} />
         </>
       );
     case "chat":
       return (
         <>
-          <UserList
-            listOf={"participant"}
-            setProfileUser={props.setProfileUser}
-            chatUserList={props.chatUsers}
-          />
-          <UserList
-            listOf={"banned"}
-            setProfileUser={props.setProfileUser}
-            chatUserList={props.chatUsers}
-          />
+          <UserList listOf={"participant"} chatUserList={props.chatUsers} />
+          <UserList listOf={"banned"} chatUserList={props.chatUsers} />
         </>
       );
     case "game":
       return (
         <>
-          <UserList listOf="player" setProfileUser={props.setProfileUser} />
-          <UserList listOf="observer" setProfileUser={props.setProfileUser} />
+          <UserList listOf="player" />
+          <UserList listOf="observer" />
         </>
       );
   }

--- a/src/components/rightSide/RightSide.tsx
+++ b/src/components/rightSide/RightSide.tsx
@@ -2,14 +2,11 @@ import { ChatUserListType } from "socket/chat";
 import MyProfile from "./MyProfile";
 import OtherUserList from "./OtherUserList";
 
-export default function RightSide(props: {
-  inPageOf: "main" | "chat" | "game";
-  userList: ChatUserListType | null;
-}) {
+export default function RightSide(props: { userList: ChatUserListType | null }) {
   return (
     <>
       <MyProfile />
-      <OtherUserList inPageOf={props.inPageOf} chatUsers={props.userList} />
+      <OtherUserList chatUsers={props.userList} />
     </>
   );
 }

--- a/src/components/rightSide/RightSide.tsx
+++ b/src/components/rightSide/RightSide.tsx
@@ -10,7 +10,11 @@ export default function RightSide(props: {
   return (
     <>
       <MyProfile setProfileUser={props.setProfileUser} />
-      <OtherUserList inPageOf={props.inPageOf} setProfileUser={props.setProfileUser} chatUsers={props.userList}/>
+      <OtherUserList
+        inPageOf={props.inPageOf}
+        setProfileUser={props.setProfileUser}
+        chatUsers={props.userList}
+      />
     </>
   );
 }

--- a/src/components/rightSide/RightSide.tsx
+++ b/src/components/rightSide/RightSide.tsx
@@ -4,17 +4,12 @@ import OtherUserList from "./OtherUserList";
 
 export default function RightSide(props: {
   inPageOf: "main" | "chat" | "game";
-  setProfileUser: (userId: string) => void;
   userList: ChatUserListType | null;
 }) {
   return (
     <>
-      <MyProfile setProfileUser={props.setProfileUser} />
-      <OtherUserList
-        inPageOf={props.inPageOf}
-        setProfileUser={props.setProfileUser}
-        chatUsers={props.userList}
-      />
+      <MyProfile />
+      <OtherUserList inPageOf={props.inPageOf} chatUsers={props.userList} />
     </>
   );
 }

--- a/src/components/rightSide/UserInfo.tsx
+++ b/src/components/rightSide/UserInfo.tsx
@@ -1,0 +1,27 @@
+import { useContext } from "react";
+import { ProfileContext } from "@hooks/ProfileContext";
+import * as S from "./style";
+
+export default function UserInfo(props: {
+  username: string;
+  subLine: string;
+  handleDrop: () => void;
+}) {
+  const setProfileUser = useContext(ProfileContext);
+
+  return (
+    <>
+      <S.TmpImg />
+      <S.UserInfo
+        onClick={() => {
+          setProfileUser && setProfileUser(props.username);
+        }}
+      >
+        {props.username}
+        <br />
+        {props.subLine}
+      </S.UserInfo>
+      <S.MoreIcon onClick={props.handleDrop} />
+    </>
+  );
+}

--- a/src/components/rightSide/UserInfo.tsx
+++ b/src/components/rightSide/UserInfo.tsx
@@ -5,7 +5,7 @@ import * as S from "./style";
 export default function UserInfo(props: {
   username: string;
   subLine: string;
-  handleDrop: () => void;
+  handleDrop?: () => void;
 }) {
   const setProfileUser = useContext(ProfileContext);
 
@@ -21,7 +21,7 @@ export default function UserInfo(props: {
         <br />
         {props.subLine}
       </S.UserInfo>
-      <S.MoreIcon onClick={props.handleDrop} />
+      {props.handleDrop && <S.MoreIcon onClick={props.handleDrop} />}
     </>
   );
 }

--- a/src/components/rightSide/UserList.tsx
+++ b/src/components/rightSide/UserList.tsx
@@ -2,13 +2,14 @@ import { useQuery } from "@tanstack/react-query";
 import { getProfile } from "@api/user";
 import * as S from "./style";
 import { ChatUserListType } from "socket/chat";
-import { useRef, useState } from "react";
+import { useContext, useRef, useState } from "react";
+import { ProfileContext } from "@hooks/ProfileContext";
 
 export default function UserList(props: {
   listOf: "friend" | "dm" | "participant" | "banned" | "player" | "observer";
-  setProfileUser: (userId: string) => void;
   chatUserList?: ChatUserListType | null;
 }) {
+  const setProfileUser = useContext(ProfileContext);
   let cnt = 0;
   const [dropMenu, setDropMenu] = useState(false);
   const [id, setId] = useState("");
@@ -24,6 +25,10 @@ export default function UserList(props: {
 
   if (profileQuery.isLoading) return <S.UserListLayout></S.UserListLayout>;
   if (profileQuery.isError) console.log(profileQuery.error);
+
+  // friend, dm -> 메인/소켓
+  // participant, banned -> 채팅/소켓
+  // player, observer -> 게임/소켓
 
   const onDropMenuHandler = (e: React.MouseEvent<HTMLDivElement>) => {
     setId(e.currentTarget.id);
@@ -51,7 +56,12 @@ export default function UserList(props: {
             );
           })}
         {props.listOf !== "participant" && (
-          <S.UserItem key={1} onClick={() => props.setProfileUser(profileQuery?.data.username)}>
+          <S.UserItem
+            key={1}
+            onClick={() => {
+              setProfileUser && setProfileUser(profileQuery?.data.username);
+            }}
+          >
             <S.TmpImg />
             <span>
               {profileQuery?.data?.username}

--- a/src/components/rightSide/UserList.tsx
+++ b/src/components/rightSide/UserList.tsx
@@ -1,20 +1,16 @@
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getProfile } from "@api/user";
-import * as S from "./style";
 import { ChatUserListType } from "socket/chat";
-import { useContext, useRef, useState } from "react";
-import { ProfileContext } from "@hooks/ProfileContext";
+import UserInfo from "./UserInfo";
+import * as S from "./style";
 
 export default function UserList(props: {
   listOf: "friend" | "dm" | "participant" | "banned" | "player" | "observer";
   chatUserList?: ChatUserListType | null;
 }) {
-  const setProfileUser = useContext(ProfileContext);
-  let cnt = 0;
-  const [dropMenu, setDropMenu] = useState(false);
-  const [id, setId] = useState("");
-  const userRef = useRef<HTMLLIElement>(null);
-  // 테스트할 때는 회원가입된 다른 유저의 username을 아무개 대신 넣어주세요!
+  const [isDrop, setIsDrop] = useState(false);
+
   // 임시 쿼리. 친구 리스트 불러오는 api 필요
   const profileQuery = useQuery({
     queryKey: ["profile", "아무개"],
@@ -30,12 +26,11 @@ export default function UserList(props: {
   // participant, banned -> 채팅/소켓
   // player, observer -> 게임/소켓
 
-  const onDropMenuHandler = (e: React.MouseEvent<HTMLDivElement>) => {
-    setId(e.currentTarget.id);
-    console.log(e);
-    if (!dropMenu) setDropMenu(true);
-    else setDropMenu(false);
-  };
+  // 유저네임 받을 예정
+  function handleDrop() {
+    setIsDrop(!isDrop);
+  }
+
   return (
     <S.UserListLayout>
       <h3>{props.listOf}</h3>
@@ -43,31 +38,25 @@ export default function UserList(props: {
         {props.listOf === "participant" &&
           props.chatUserList?.userList.map((user) => {
             return (
-              <S.UserItem key={cnt++} ref={userRef}>
-                <S.TmpImg id={user.username} onClick={onDropMenuHandler} />
-                <span>
-                  {user.username}
-                  <br />
-                  {user.owner && "방장"}
-                  {user.admin && "관리자"}
-                </span>
-                {dropMenu && user.username === id && <>hihi</>}
+              <S.UserItem key={user.username}>
+                <UserInfo
+                  username={user.username + (user.owner ? " 👑" : user.admin ? " 🎩" : "")}
+                  subLine={user.login ? "🔵 온라인" : "⚫️ 오프라인"}
+                  handleDrop={handleDrop}
+                />
+                {isDrop && <>hihi</>}
               </S.UserItem>
             );
           })}
         {props.listOf !== "participant" && (
-          <S.UserItem
-            key={1}
-            onClick={() => {
-              setProfileUser && setProfileUser(profileQuery?.data.username);
-            }}
-          >
-            <S.TmpImg />
-            <span>
-              {profileQuery?.data?.username}
-              <br />
-              {profileQuery?.data?.status === "login" ? "🔵 온라인" : "⚫️ 오프라인"}
-            </span>
+          // 이벤트에 대한 데이터. key 값에 username 넣을 예정
+          <S.UserItem>
+            <UserInfo
+              username={profileQuery?.data?.username}
+              subLine={profileQuery?.data?.status === "login" ? "🔵 온라인" : "⚫️ 오프라인"}
+              handleDrop={handleDrop}
+            />
+            {isDrop && <>hihi</>}
           </S.UserItem>
         )}
       </S.UserList>

--- a/src/components/rightSide/UserList.tsx
+++ b/src/components/rightSide/UserList.tsx
@@ -5,11 +5,18 @@ import { ChatUserListType } from "socket/chat";
 import UserInfo from "./UserInfo";
 import * as S from "./style";
 
+// friend, dm -> 메인/소켓
+// participant, banned -> 채팅/소켓
+// player, observer -> 게임/소켓
 export default function UserList(props: {
   listOf: "friend" | "dm" | "participant" | "banned" | "player" | "observer";
   chatUserList?: ChatUserListType | null;
 }) {
   const [isDrop, setIsDrop] = useState(false);
+
+  function handleDrop() {
+    setIsDrop(!isDrop);
+  }
 
   // 임시 쿼리. 친구 리스트 불러오는 api 필요
   const profileQuery = useQuery({
@@ -21,15 +28,6 @@ export default function UserList(props: {
 
   if (profileQuery.isLoading) return <S.UserListLayout></S.UserListLayout>;
   if (profileQuery.isError) console.log(profileQuery.error);
-
-  // friend, dm -> 메인/소켓
-  // participant, banned -> 채팅/소켓
-  // player, observer -> 게임/소켓
-
-  // 유저네임 받을 예정
-  function handleDrop() {
-    setIsDrop(!isDrop);
-  }
 
   return (
     <S.UserListLayout>
@@ -48,8 +46,20 @@ export default function UserList(props: {
               </S.UserItem>
             );
           })}
-        {props.listOf !== "participant" && (
-          // 이벤트에 대한 데이터. key 값에 username 넣을 예정
+        {
+          // TODO: 소켓 이벤트 데이터 연동 필요, key 값에 username
+          props.listOf === "banned" && (
+            <S.UserItem>
+              <UserInfo
+                username={profileQuery?.data?.username}
+                subLine="❌ 입장금지"
+                handleDrop={handleDrop}
+              />
+              {isDrop && <>hihi</>}
+            </S.UserItem>
+          )
+        }
+        {!["participant", "banned"].includes(props.listOf) && (
           <S.UserItem>
             <UserInfo
               username={profileQuery?.data?.username}

--- a/src/components/rightSide/UserList.tsx
+++ b/src/components/rightSide/UserList.tsx
@@ -5,7 +5,7 @@ import { ChatUserListType } from "socket/chat";
 import { useRef, useState } from "react";
 
 export default function UserList(props: {
-  listOf: "friend" | "dm" | "participant" | "player" | "observer";
+  listOf: "friend" | "dm" | "participant" | "banned" | "player" | "observer";
   setProfileUser: (userId: string) => void;
   chatUserList?: ChatUserListType | null;
 }) {
@@ -38,8 +38,8 @@ export default function UserList(props: {
         {props.listOf === "participant" &&
           props.chatUserList?.userList.map((user) => {
             return (
-              <S.UserItem key={cnt++} ref={userRef} >
-                <S.TmpImg id={user.username} onClick={onDropMenuHandler}/>
+              <S.UserItem key={cnt++} ref={userRef}>
+                <S.TmpImg id={user.username} onClick={onDropMenuHandler} />
                 <span>
                   {user.username}
                   <br />

--- a/src/components/rightSide/style.tsx
+++ b/src/components/rightSide/style.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { MdOutlineMoreVert } from "react-icons/md";
 
 /*
  *          My Profile
@@ -21,7 +22,7 @@ export const UserListLayout = styled.div`
   flex-direction: column;
   flex: 1 0 auto;
 
-  padding: 8px 10px;
+  padding: 8px 5px 8px 10px;
   border-top: 0.5px solid black;
   border-left: 0.5px solid black;
 `;
@@ -43,7 +44,6 @@ export const UserItem = styled.li`
   align-items: center;
 
   list-type: none;
-  cursor: pointer;
 `;
 
 export const TmpImg = styled.div`
@@ -51,4 +51,16 @@ export const TmpImg = styled.div`
   height: 50px;
   border-radius: 100%;
   background-color: gray;
+  cursor: pointer;
+`;
+
+export const UserInfo = styled.span`
+  cursor: pointer;
+`;
+
+export const MoreIcon = styled(MdOutlineMoreVert)`
+  width: 20px;
+  height: 100%;
+  margin-left: auto;
+  cursor: pointer;
 `;

--- a/src/hooks/ProfileContext.ts
+++ b/src/hooks/ProfileContext.ts
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+type setProfileUser = React.Dispatch<React.SetStateAction<string>>;
+
+export const ProfileContext = createContext<setProfileUser | null>(null);

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -1,0 +1,11 @@
+import { useState, useCallback, ChangeEvent } from "react";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function useInput(initialValue: any) {
+  const [input, setInput] = useState(initialValue);
+  const handler = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setInput(e.target.value);
+  }, []);
+  const reset = useCallback(() => setInput(initialValue), [initialValue]);
+  return [input, handler, reset] as const;
+}

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -5,7 +5,7 @@ import Main from "@page/main/Main";
 import Profile from "@leftSide/profile/Profile";
 import ListTabBar from "@centerHeader/ListTabBar";
 import RightSide from "@rightSide/RightSide";
-import * as S from "./style";
+import { ProfileContext } from "@hooks/ProfileContext";
 import loadable from "@loadable/component";
 import NotFound from "pages/NotFound";
 import {
@@ -15,6 +15,7 @@ import {
   updateChatRoomList,
   updateMyChatRoomList,
 } from "socket/chat";
+import * as S from "./style";
 
 const ChatList = loadable(() => {
   return import("@page/chat/chatList/ChatList");
@@ -40,42 +41,44 @@ function Auth() {
   useEffect(() => {
     updateChatRoomList(setChatList);
     updateMyChatRoomList(setMyChatList);
-  }, );
+  });
 
   useEffect(() => {
     updateChatRoom(roomId, setChatUserList);
-  }, );
+  });
 
   return (
     <S.AppLayout>
       <BrowserRouter>
-        <S.LeftSideLayout>
-          <Profile username={profileUser} />
-        </S.LeftSideLayout>
-        <S.CenterLayout>
-          <ListTabBar />
-          <Routes>
-            <Route path="/" element={<Main setPage={setInPageOf} />} />
-            <Route
-              path="/chat/list"
-              element={
-                <ChatList
-                  setPage={setInPageOf}
-                  chatRoom={chatList}
-                  myChatRoom={myChatList}
-                  setRoom={setRoomId}
-                />
-              }
-            />
-            <Route path="/game/list" element={<GameList setPage={setInPageOf} />} />
-            <Route path="/chat/:roomId" element={<ChatRoom setPage={setInPageOf} />} />
-            <Route path="/game/:gameId" element={<GameRoom setPage={setInPageOf} />} />
-            <Route path="/*" element={<NotFound />} />
-          </Routes>
-        </S.CenterLayout>
-        <S.RightSideLayout>
-          <RightSide inPageOf={inPageOf} setProfileUser={setProfileUser} userList={chatUserList} />
-        </S.RightSideLayout>
+        <ProfileContext.Provider value={setProfileUser}>
+          <S.LeftSideLayout>
+            <Profile username={profileUser} />
+          </S.LeftSideLayout>
+          <S.CenterLayout>
+            <ListTabBar />
+            <Routes>
+              <Route path="/" element={<Main setPage={setInPageOf} />} />
+              <Route
+                path="/chat/list"
+                element={
+                  <ChatList
+                    setPage={setInPageOf}
+                    chatRoom={chatList}
+                    myChatRoom={myChatList}
+                    setRoom={setRoomId}
+                  />
+                }
+              />
+              <Route path="/game/list" element={<GameList setPage={setInPageOf} />} />
+              <Route path="/chat/:roomId" element={<ChatRoom setPage={setInPageOf} />} />
+              <Route path="/game/:gameId" element={<GameRoom setPage={setInPageOf} />} />
+              <Route path="/*" element={<NotFound />} />
+            </Routes>
+          </S.CenterLayout>
+          <S.RightSideLayout>
+            <RightSide inPageOf={inPageOf} userList={chatUserList} />
+          </S.RightSideLayout>
+        </ProfileContext.Provider>
       </BrowserRouter>
     </S.AppLayout>
   );

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -32,7 +32,6 @@ const GameRoom = loadable(() => {
 
 function Auth() {
   const [profileUser, setProfileUser] = useState(getUsername());
-  const [inPageOf, setInPageOf] = useState<"main" | "chat" | "game">("main");
   const [chatList, setChatList] = useState<ChatListType[]>([]);
   const [myChatList, setMyChatList] = useState<ChatListType[]>([]);
   const [chatUserList, setChatUserList] = useState<ChatUserListType | null>(null);
@@ -57,26 +56,21 @@ function Auth() {
           <S.CenterLayout>
             <ListTabBar />
             <Routes>
-              <Route path="/" element={<Main setPage={setInPageOf} />} />
+              <Route path="/" element={<Main />} />
               <Route
                 path="/chat/list"
                 element={
-                  <ChatList
-                    setPage={setInPageOf}
-                    chatRoom={chatList}
-                    myChatRoom={myChatList}
-                    setRoom={setRoomId}
-                  />
+                  <ChatList chatRoom={chatList} myChatRoom={myChatList} setRoom={setRoomId} />
                 }
               />
-              <Route path="/game/list" element={<GameList setPage={setInPageOf} />} />
-              <Route path="/chat/:roomId" element={<ChatRoom setPage={setInPageOf} />} />
-              <Route path="/game/:gameId" element={<GameRoom setPage={setInPageOf} />} />
+              <Route path="/game/list" element={<GameList />} />
+              <Route path="/chat/:roomId" element={<ChatRoom />} />
+              <Route path="/game/:gameId" element={<GameRoom />} />
               <Route path="/*" element={<NotFound />} />
             </Routes>
           </S.CenterLayout>
           <S.RightSideLayout>
-            <RightSide inPageOf={inPageOf} userList={chatUserList} />
+            <RightSide userList={chatUserList} />
           </S.RightSideLayout>
         </ProfileContext.Provider>
       </BrowserRouter>

--- a/src/pages/auth/chat/chatList/ChatList.tsx
+++ b/src/pages/auth/chat/chatList/ChatList.tsx
@@ -1,13 +1,12 @@
-import { Dispatch, SetStateAction, useContext, useEffect, useState } from "react";
+import { Dispatch, SetStateAction } from "react";
 import { useNavigate } from "react-router-dom";
-import { getAuth, isAuth } from "userAuth";
+import { isAuth } from "userAuth";
 import ChatItem from "./ChatItem";
 import * as S from "./style";
 import CreateChatRoom from "./create/CreateBtn";
 import { ChatListType } from "socket/chat";
 
 type propsType = {
-  setPage: (page: "main") => void;
   chatRoom: ChatListType[];
   myChatRoom: ChatListType[];
   setRoom: Dispatch<SetStateAction<number | undefined>>;
@@ -15,19 +14,15 @@ type propsType = {
 
 export default function ChatList(props: propsType) {
   const navigate = useNavigate();
+  if (!isAuth()) navigate("/");
   let no1 = 1;
   let no2 = 1;
-
-  useEffect(() => {
-    if (!isAuth()) navigate("/");
-    props.setPage("main");
-  }, []);
 
   return (
     <S.PageLayout>
       <S.HeaderBox>
         <S.H2>참여 가능한 채팅방</S.H2>
-        <CreateChatRoom setRoom={props.setRoom}/>
+        <CreateChatRoom setRoom={props.setRoom} />
       </S.HeaderBox>
       <S.ChatList>
         <S.ChatItem head>

--- a/src/pages/auth/chat/chatRoom/ChatRoom.tsx
+++ b/src/pages/auth/chat/chatRoom/ChatRoom.tsx
@@ -1,22 +1,14 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { isAuth } from "userAuth";
-import { Dispatch, SetStateAction, useEffect } from "react";
 import * as S from "./style";
 import Send from "./SendBtn";
 import Screen from "./Screen";
 import Exit from "./ExitBtn";
 
-type PropsType = {
-  setPage: (page: "chat") => void;
-};
-
-export default function ChatRoom(props: PropsType) {
-  const { roomId } = useParams();
+export default function ChatRoom() {
   const navigate = useNavigate();
-  useEffect(() => {
-    if (!isAuth()) navigate("/");
-    props.setPage("chat");
-  });
+  if (!isAuth()) navigate("/");
+  const { roomId } = useParams();
 
   return (
     <S.PageLayout>

--- a/src/pages/auth/chat/chatRoom/ChatRoom.tsx
+++ b/src/pages/auth/chat/chatRoom/ChatRoom.tsx
@@ -9,6 +9,7 @@ export default function ChatRoom() {
   const navigate = useNavigate();
   if (!isAuth()) navigate("/");
   const { roomId } = useParams();
+  if (Number.isNaN(Number(roomId))) navigate("/404");
 
   return (
     <S.PageLayout>

--- a/src/pages/auth/game/gameList/GameList.tsx
+++ b/src/pages/auth/game/gameList/GameList.tsx
@@ -1,15 +1,11 @@
-import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { isAuth } from "userAuth";
 import GameItem from "./GameItem";
 import * as S from "./style";
 
-export default function GameList(props: { setPage: (page: "main") => void }) {
+export default function GameList() {
   const navigate = useNavigate();
-  useEffect(() => {
-    if (!isAuth()) navigate("/");
-    props.setPage("main");
-  });
+  if (!isAuth()) navigate("/");
 
   let gameCnt = 0;
   // 임시 더미데이터

--- a/src/pages/auth/game/gameRoom/GameRoom.tsx
+++ b/src/pages/auth/game/gameRoom/GameRoom.tsx
@@ -6,6 +6,7 @@ export default function GameRoom() {
   const navigate = useNavigate();
   if (!isAuth()) navigate("/");
   const { gameId } = useParams();
+  if (Number.isNaN(Number(gameId))) navigate("/404");
 
   return (
     <S.PageLayout>

--- a/src/pages/auth/game/gameRoom/GameRoom.tsx
+++ b/src/pages/auth/game/gameRoom/GameRoom.tsx
@@ -1,15 +1,11 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { isAuth } from "userAuth";
-import { useEffect } from "react";
 import * as S from "./style";
 
-export default function GameRoom(props: { setPage: (page: "game") => void }) {
-  const { gameId } = useParams();
+export default function GameRoom() {
   const navigate = useNavigate();
-  useEffect(() => {
-    if (!isAuth()) navigate("/");
-    props.setPage("game");
-  });
+  if (!isAuth()) navigate("/");
+  const { gameId } = useParams();
 
   return (
     <S.PageLayout>

--- a/src/pages/auth/main/Main.tsx
+++ b/src/pages/auth/main/Main.tsx
@@ -1,14 +1,10 @@
-import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { isAuth } from "userAuth";
 import * as S from "./style";
 
-export default function Main(props: { setPage: (page: "main" | "chat" | "game") => void }) {
+export default function Main() {
   const navigate = useNavigate();
-  useEffect(() => {
-    if (!isAuth()) navigate("/");
-    props.setPage("main");
-  });
+  if (!isAuth()) navigate("/");
 
   return (
     <S.MainLayout>


### PR DESCRIPTION
## 개요
- 채팅방 내의 유저 목록 업데이트

## 작업사항
- "chat" 페이지에서의 유저리스트 형태 리팩토링
- 오른쪽 컴포넌트에서 `roomId` 조회
- `inPageOf` 대신 url에서 page 조회
- 채팅방별 유저 목록 분리
- 왼쪽 프로필의 유저 context로 관리
- 방장과 admin 구분하는 아이콘 삽입
- ban 유저리스트 구현 (데이터는 소켓 이벤트 수정 후 연동 예정)

## 변경로직
- `Auth`에서의 `setProfileUser` 함수 context로 이동
- `Auth`에서의 `inPageOf` state 삭제, 각 url로 조회
- `UserList`의 중복 내용 `UserInfo` 컴포넌트로 관리

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
