### PR TITLE
fix: username과 icon 분리 #53

### DIFF
--- a/src/components/rightSide/UserInfo.tsx
+++ b/src/components/rightSide/UserInfo.tsx
@@ -4,6 +4,7 @@ import * as S from "./style";
 
 export default function UserInfo(props: {
   username: string;
+  icon?: string;
   subLine: string;
   handleDrop?: () => void;
 }) {
@@ -11,13 +12,17 @@ export default function UserInfo(props: {
 
   return (
     <>
-      <S.TmpImg />
+      <S.TmpImg
+        onClick={() => {
+          setProfileUser && setProfileUser(props.username);
+        }}
+      />
       <S.UserInfo
         onClick={() => {
           setProfileUser && setProfileUser(props.username);
         }}
       >
-        {props.username}
+        {props.username} {props.icon}
         <br />
         {props.subLine}
       </S.UserInfo>

--- a/src/components/rightSide/UserList.tsx
+++ b/src/components/rightSide/UserList.tsx
@@ -53,7 +53,8 @@ export default function UserList(props: {
             return (
               <S.UserItem key={user.username}>
                 <UserInfo
-                  username={user.username + (user.owner ? " 👑" : user.admin ? " 🎩" : "")}
+                  username={user.username}
+                  icon={user.owner ? "👑" : user.admin ? "🎩" : ""}
                   subLine={user.login ? "🔵 온라인" : "⚫️ 오프라인"}
                   handleDrop={() => {
                     handleDrop(user.username);


### PR DESCRIPTION
## 개요
- 이모지가 있는 경우 프로필 렌더링 오류

## 작업사항
- username 온전하게 유지
- 이모지는 분리하여 새 prop으로 처리

## 변경로직

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
