### PR TITLE
feat: 초대 알림/유저 드롭다운 메뉴 UI 구현 #59

### DIFF
--- a/src/components/rightSide/MyProfile.tsx
+++ b/src/components/rightSide/MyProfile.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { getProfile } from "api/user";
 import { getUsername } from "userAuth";
-import UserInfo from "./UserInfo";
+import UserInfo from "./user/UserInfo";
 import * as S from "./style";
 
 export default function MyProfile() {

--- a/src/components/rightSide/UserList.tsx
+++ b/src/components/rightSide/UserList.tsx
@@ -3,7 +3,8 @@ import { useQuery } from "@tanstack/react-query";
 import { getProfile } from "api/user";
 import { getSocket } from "socket/socket";
 import { ChatUserListType } from "socket/chat";
-import UserInfo from "./UserInfo";
+import UserInfo from "./user/UserInfo";
+import UserDropMenu from "./user/UserDropMenu";
 import * as S from "./style";
 
 // friend, dm -> 메인/소켓
@@ -92,6 +93,7 @@ export default function UserList(props: {
           </S.UserItem>
         )}
       </S.UserList>
+      <UserDropMenu />
     </S.UserListLayout>
   );
 }

--- a/src/components/rightSide/style.tsx
+++ b/src/components/rightSide/style.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { MdOutlineMoreVert } from "react-icons/md";
 
 /*
  *          My Profile
@@ -9,7 +8,7 @@ export const MyProfileLayout = styled.div`
   display: flex;
   flex-direction: column;
 
-  padding: 8px 10px;
+  padding: 8px 5px 8px 10px;
   border-left: 0.5px solid black;
 `;
 
@@ -42,25 +41,5 @@ export const UserItem = styled.li`
   display: flex;
   gap: 10px;
   align-items: center;
-
-  list-type: none;
-`;
-
-export const TmpImg = styled.div`
-  width: 50px;
-  height: 50px;
-  border-radius: 100%;
-  background-color: gray;
-  cursor: pointer;
-`;
-
-export const UserInfo = styled.span`
-  cursor: pointer;
-`;
-
-export const MoreIcon = styled(MdOutlineMoreVert)`
-  width: 20px;
-  height: 100%;
-  margin-left: auto;
-  cursor: pointer;
+  list-style-type: none;
 `;

--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -1,0 +1,14 @@
+import * as S from "./style";
+
+export default function UserDropMenu() {
+  return (
+    <S.DropMenuLayout>
+      <S.DropMenuItemBox>프로필</S.DropMenuItemBox>
+      <S.DropMenuItemBox>DM 보내기</S.DropMenuItemBox>
+      <S.DropMenuItemBox>게임 신청</S.DropMenuItemBox>
+      <S.DropMenuItemBox>부방장 지정</S.DropMenuItemBox>
+      <S.DropMenuItemBox>내보내기</S.DropMenuItemBox>
+      <S.DropMenuItemBox>입장 금지</S.DropMenuItemBox>
+    </S.DropMenuLayout>
+  );
+}

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -17,7 +17,7 @@ export default function UserInfo(props: {
           setProfileUser && setProfileUser(props.username);
         }}
       />
-      <S.UserInfo
+      <S.UserInfoText
         onClick={() => {
           setProfileUser && setProfileUser(props.username);
         }}
@@ -25,8 +25,16 @@ export default function UserInfo(props: {
         {props.username} {props.icon}
         <br />
         {props.subLine}
-      </S.UserInfo>
-      {props.handleDrop && <S.MoreIcon onClick={props.handleDrop} />}
+      </S.UserInfoText>
+      {props.handleDrop && <S.KebabIcon onClick={props.handleDrop} />}
+      {/* TODO: props.handleDrop 대신 알림 모달창 띄우는 handler를 prop으로 받아 조건 변경 필요 */}
+      {props.handleDrop || (
+        <>
+          {/* TODO: 새 초대가 있는 경우/없는 경우 조건 추가 */}
+          <S.EmptyInviteIcon />
+          <S.NewInviteIcon />
+        </>
+      )}
     </>
   );
 }

--- a/src/components/rightSide/user/style.tsx
+++ b/src/components/rightSide/user/style.tsx
@@ -1,0 +1,60 @@
+import styled from "@emotion/styled";
+import { MdOutlineMoreVert } from "react-icons/md";
+import { VscBell, VscBellDot } from "react-icons/vsc";
+
+/*
+ *          User Info
+ */
+
+export const TmpImg = styled.div`
+  width: 50px;
+  height: 50px;
+  border-radius: 100%;
+  background-color: gray;
+  cursor: pointer;
+`;
+
+export const UserInfoText = styled.span`
+  cursor: pointer;
+`;
+
+export const KebabIcon = styled(MdOutlineMoreVert)`
+  width: 20px;
+  height: 100%;
+  margin-left: auto;
+  cursor: pointer;
+`;
+
+export const EmptyInviteIcon = styled(VscBell)`
+  width: 16px;
+  padding: 2px;
+  height: 100%;
+  margin-left: auto;
+`;
+
+export const NewInviteIcon = styled(VscBellDot)`
+  width: 16px;
+  padding: 2px;
+  height: 100%;
+  margin-left: auto;
+`;
+
+/*
+ *          Drop Menu
+ */
+
+export const DropMenuLayout = styled.div`
+  width: 80px;
+  border: 1px solid black;
+  border-bottom: 0;
+`;
+
+export const DropMenuItemBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 80px;
+  height: 20px;
+  border-bottom: 1px solid black;
+`;


### PR DESCRIPTION
## 개요
- 초대 알림/유저 드롭다운 메뉴 UI 구현

## 작업사항
- `MyProfile` 내부에 알림 아이콘 삽입 (초대 있는 경우/없는 경우)
- 유저 드롭다운 메뉴 UI 구현
- `UserList` 파일이 많아져서 유저 개인에 대한 디렉토리로 user 생성

## 변경로직

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
