### PR TITLE
feat: 페이지마다 필요한 리스트 고려하여 재구현 #62 

### DIFF
--- a/src/components/rightSide/FriendAndDmBar.tsx
+++ b/src/components/rightSide/FriendAndDmBar.tsx
@@ -8,9 +8,7 @@ export default function FriendAndDmBar() {
   // TODO: dm 이벤트에 따라 set 함수 사용
 
   function handleClick(e) {
-    e.stopPropagation();
-    console.log(e.target);
-    // console.log(e.target.id);
+    if (e.target.id === "dm") setIsNewDm(false);
     if (e.target.id === isOpen) setIsOpen("");
     else setIsOpen(e.target.id);
   }

--- a/src/components/rightSide/OtherUserList.tsx
+++ b/src/components/rightSide/OtherUserList.tsx
@@ -4,18 +4,11 @@ import UserList from "./user/UserList";
 export default function OtherUserList() {
   const path = useLocation().pathname;
   const split = path.split("/");
-  let page = split[1];
+  const page = split[1];
   const roomId = split[2];
-  if (roomId === undefined || roomId === "list") page = "main";
+  if (roomId === undefined || roomId === "list") return null;
 
   switch (page) {
-    case "main":
-      return (
-        <>
-          {/* <UserList listOf={"friend"} /> */}
-          {/* <UserList listOf={"dm"} /> */}
-        </>
-      );
     case "chat":
       return (
         <>


### PR DESCRIPTION
## 개요
- 페이지마다 필요한 리스트 고려하여 재구현

## 작업사항
- friend/dm 전체 페이지에서 조회 가능하도록 분리
- main에서의 기존 유저리스트 컴포넌트 렌더링 삭제
- 아이콘 클릭 시 조회 가능 (한 공간만 차지)

## 변경로직
- friend/dm 리스트 메뉴바로 분리

## 코멘트
- 제일 작업 많이한 커밋은..메인에...찍혀있습니다 다음부터 주의하겠습니다!

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
