### PR TITLE
refact: getavatar react query #77

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -36,8 +36,8 @@ export async function create(userInfo: userInfoType) {
 
 export async function getAvatar(username: string) {
   try {
-    const res = await axios.get<Blob>(`/user/avatar/${username}`, {
-      responseType: 'blob'
+    const res = await axios.get<Blob | string>(`/user/avatar/${username}`, {
+      responseType: "blob",
     });
     return res;
   } catch (err: unknown) {
@@ -50,7 +50,7 @@ export async function getAvatar(username: string) {
 
 export async function postAvatar(form: FormData) {
   try {
-    const res = await axios.post('/user/avatar', form);
+    const res = await axios.post("/user/avatar", form);
     return res;
   } catch (err: unknown) {
     if (err instanceof AxiosError && err.response) {

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -36,10 +36,10 @@ export async function create(userInfo: userInfoType) {
 
 export async function getAvatar(username: string) {
   try {
-    const res = await axios.get<Blob | string>(`/user/avatar/${username}`, {
+    const res = await axios.get<Blob>(`/user/avatar/${username}`, {
       responseType: "blob",
     });
-    return res;
+    return window.URL.createObjectURL(res.data);
   } catch (err: unknown) {
     if (err instanceof AxiosError && err.response) {
       console.error(err.response);

--- a/src/components/leftSide/Profile.tsx
+++ b/src/components/leftSide/Profile.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getAvatar, getProfile } from "api/user";
+import { getProfile } from "api/user";
 import { ProfileData } from "./ProfileData";
 
 export default function Profile(props: { username?: string }) {

--- a/src/components/leftSide/Profile.tsx
+++ b/src/components/leftSide/Profile.tsx
@@ -11,6 +11,7 @@ export default function Profile(props: { username?: string }) {
   });
 
   if (profileQuery.isLoading) return <ProfileData />;
+  console.log(profileQuery.data);
 
   return <ProfileData user={profileQuery.data} />;
 }

--- a/src/components/leftSide/Profile.tsx
+++ b/src/components/leftSide/Profile.tsx
@@ -11,7 +11,6 @@ export default function Profile(props: { username?: string }) {
   });
 
   if (profileQuery.isLoading) return <ProfileData />;
-  console.log(profileQuery.data);
 
   return <ProfileData user={profileQuery.data} />;
 }

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -68,7 +68,7 @@ export function ProfileData(props: userProps) {
         </Modal>
       )}
       <S.Title>프로필</S.Title>
-      <S.TmpImg
+      <S.ProfileImg
         me={myProfile}
         src={String(avatarQuery.data)}
         onClick={myProfile ? openModalHandler : undefined}

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -37,23 +37,15 @@ export function ProfileData(props: userProps) {
   const navigate = useNavigate();
   const [showModal, setShowModal] = useState(false);
   const myProfile = getUsername() === props.user?.username;
-  const [img, setImg] = useState("");
 
   const avatarQuery = useQuery({
     queryKey: ["avatar", `${props.user?.username}`],
-    queryFn: ({ queryKey }) => {
-      return getAvatar(queryKey[1]);
+    queryFn: () => {
+      if (props.user) return getAvatar(props.user.username);
     },
     enabled: !!props.user,
-    onSuccess(data) {
-      const file = new File([data?.data], "avatar");
-      const reader = new FileReader();
-      reader.onload = (ev) => {
-        setImg(String(ev.target?.result));
-      };
-      reader.readAsDataURL(file);
-    },
   });
+
   if (avatarQuery.isLoading) console.log("loading");
 
   const openModalHandler = () => {
@@ -72,7 +64,11 @@ export function ProfileData(props: userProps) {
         </Modal>
       )}
       <S.Title>프로필</S.Title>
-      <S.TmpImg me={myProfile} src={`${img}`} onClick={myProfile ? openModalHandler : undefined} />
+      <S.TmpImg
+        me={myProfile}
+        src={String(avatarQuery.data)}
+        onClick={myProfile ? openModalHandler : undefined}
+      />
       <S.InfoWrapper>
         <S.InfoLabel>
           닉네임

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -60,7 +60,11 @@ export function ProfileData(props: userProps) {
     <S.ProfileLayout>
       {showModal && (
         <Modal setView={closeModalHandler}>
-          <AvatarUploadModal close={closeModalHandler} username={props.user?.username} />
+          <AvatarUploadModal
+            close={closeModalHandler}
+            prevUrl={String(avatarQuery.data)}
+            username={props.user?.username}
+          />
         </Modal>
       )}
       <S.Title>프로필</S.Title>

--- a/src/components/leftSide/style.tsx
+++ b/src/components/leftSide/style.tsx
@@ -19,10 +19,11 @@ export const Title = styled.h2`
  *      Profile Item
  */
 
-export const TmpImg = styled.img<{ me: boolean }>`
+export const ProfileImg = styled.img<{ me: boolean }>`
   width: 100px;
   height: 100px;
   border-radius: 100%;
+  flex-shrink: 0;
 
   margin: 20px auto;
   ${(props) => {

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -26,8 +26,8 @@ export default function UserInfo(props: {
 
   const avatarQuery = useQuery({
     queryKey: ["avatar", `${props.username}`],
-    queryFn: ({ queryKey }) => {
-      return getAvatar(queryKey[1]);
+    queryFn: () => {
+      if (props.username) return getAvatar(props.username);
     },
     enabled: !!props.username,
   });

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -22,7 +22,6 @@ export default function UserInfo(props: {
     listOf: props.listOf,
     username: props.username,
   });
-  const [img, setImg] = useState("");
   const { showNotiModal, NotiModal, onOpenNotiModal, newNoti } = useNotiModal();
 
   const avatarQuery = useQuery({
@@ -31,14 +30,6 @@ export default function UserInfo(props: {
       return getAvatar(queryKey[1]);
     },
     enabled: !!props.username,
-    onSuccess(data) {
-      const file = new File([data?.data], "avatar");
-      const reader = new FileReader();
-      reader.onload = (ev) => {
-        setImg(String(ev.target?.result));
-      };
-      reader.readAsDataURL(file);
-    },
   });
   if (avatarQuery.isLoading) console.log("loading");
 
@@ -46,7 +37,7 @@ export default function UserInfo(props: {
     <>
       {showNotiModal && NotiModal}
       <S.TmpImg
-        src={img}
+        src={String(avatarQuery.data)}
         me={props.listOf === undefined}
         onClick={() => {
           !props.listOf && setProfileUser && setProfileUser(props.username);

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -1,10 +1,11 @@
-import { useContext, useEffect, useState } from "react";
-import { ProfileContext, ProfileImgIsUpContext } from "hooks/context/ProfileContext";
+import { useContext, useState } from "react";
+import { ProfileContext } from "hooks/context/ProfileContext";
 import UserDropMenu from "./UserDropMenu";
 import useNotiModal from "hooks/useNotiModal";
 import useDropModal from "hooks/useDropModal";
 import { getUsername } from "userAuth";
 import { getAvatar } from "api/user";
+import { useQuery } from "@tanstack/react-query";
 import * as S from "./style";
 
 export default function UserInfo(props: {
@@ -16,7 +17,6 @@ export default function UserInfo(props: {
   banned?: boolean;
 }) {
   const setProfileUser = useContext(ProfileContext);
-  const profileImgIsUp = useContext(ProfileImgIsUpContext);
   const me = getUsername() === props.username;
   const { onDropOpen, onDropClose, dropIsOpen } = useDropModal({
     listOf: props.listOf,
@@ -25,19 +25,22 @@ export default function UserInfo(props: {
   const [img, setImg] = useState("");
   const { showNotiModal, NotiModal, onOpenNotiModal, newNoti } = useNotiModal();
 
-  useEffect(() => {
-    const getAvatarHandler = async () => {
-      const res = await getAvatar(props.username);
-      const file = new File([res?.data], "avatar");
+  const avatarQuery = useQuery({
+    queryKey: ["avatar", `${props.username}`],
+    queryFn: ({ queryKey }) => {
+      return getAvatar(queryKey[1]);
+    },
+    enabled: !!props.username,
+    onSuccess(data) {
+      const file = new File([data?.data], "avatar");
       const reader = new FileReader();
       reader.onload = (ev) => {
-        const previewImage = String(ev.target?.result);
-        setImg(previewImage);
+        setImg(String(ev.target?.result));
       };
       reader.readAsDataURL(file);
-    };
-    getAvatarHandler();
-  }, [profileImgIsUp]);
+    },
+  });
+  if (avatarQuery.isLoading) console.log("loading");
 
   return (
     <>

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -36,7 +36,7 @@ export default function UserInfo(props: {
   return (
     <>
       {showNotiModal && NotiModal}
-      <S.TmpImg
+      <S.ProfileImg
         src={String(avatarQuery.data)}
         me={props.listOf === undefined}
         onClick={() => {

--- a/src/components/rightSide/user/UserList.tsx
+++ b/src/components/rightSide/user/UserList.tsx
@@ -1,8 +1,6 @@
-import { useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getProfile } from "api/user";
 import { BanListArray, UserListArray } from "socket/passive/chatRoomType";
-import { ProfileImgIsUpContext } from "hooks/context/ProfileContext";
 import UserInfo from "./UserInfo";
 import * as S from "../style";
 
@@ -12,8 +10,6 @@ type UserListCase =
   | { listOf: "banned"; list: BanListArray | null };
 
 export default function UserList(props: UserListCase) {
-  const profileImgIsUp = useContext(ProfileImgIsUpContext);
-
   // 임시 쿼리. 친구 리스트 불러오는 api 필요
   const profileQuery = useQuery({
     queryKey: ["profile", "아무개"],

--- a/src/components/rightSide/user/style.tsx
+++ b/src/components/rightSide/user/style.tsx
@@ -7,7 +7,7 @@ import { darkGray, darkMain, lightGray, lightMain } from "style/color";
  *          User Info
  */
 
-export const TmpImg = styled.img<{ me: boolean }>`
+export const ProfileImg = styled.img<{ me: boolean }>`
   width: 50px;
   height: 50px;
   border-radius: 100%;

--- a/src/hooks/context/ProfileContext.ts
+++ b/src/hooks/context/ProfileContext.ts
@@ -1,8 +1,5 @@
 import React, { createContext } from "react";
 
 type setProfileUser = React.Dispatch<React.SetStateAction<string>>;
-type setProfileImgIsUp = React.Dispatch<React.SetStateAction<boolean>>;
 
 export const ProfileContext = createContext<setProfileUser | null>(null);
-export const ProfileImgIsUpContext = createContext<boolean | null>(null);
-export const ProfileSetImgIsUpContext = createContext<setProfileImgIsUp | null>(null);

--- a/src/modal/AvatarUploadModal.tsx
+++ b/src/modal/AvatarUploadModal.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 type modalProps = {
   username: string | undefined;
+  prevUrl: string;
   close: () => void;
 };
 
@@ -24,11 +25,12 @@ function AvatarUploadModal(props: modalProps) {
     onSuccess: (res) => {
       if (res?.status === 201) {
         queryCli.invalidateQueries(["avatar", props.username]);
+        URL.revokeObjectURL(props.prevUrl);
         props.close();
       } else {
         setNoti(res ? res.data.message : "");
       }
-    }
+    },
   });
 
   const uploadAvatarHandler = (e: React.MouseEvent<HTMLFormElement>) => {

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -6,11 +6,7 @@ import Main from "@page/main/Main";
 import Profile from "@leftSide/Profile";
 import ListTabBar from "@header/ListTabBar";
 import NotFound from "pages/NotFound";
-import {
-  ProfileContext,
-  ProfileImgIsUpContext,
-  ProfileSetImgIsUpContext,
-} from "hooks/context/ProfileContext";
+import { ProfileContext } from "hooks/context/ProfileContext";
 import { getSocket } from "socket/socket";
 import * as S from "./style";
 
@@ -45,26 +41,22 @@ function Auth() {
     <S.AppLayout>
       <BrowserRouter>
         <ProfileContext.Provider value={setProfileUser}>
-          <ProfileImgIsUpContext.Provider value={profileImgIsUp}>
-            <ProfileSetImgIsUpContext.Provider value={setProfileImgIsUp}>
-              <ListTabBar />
-              <S.HomeLayout>
-                <S.LeftSideLayout>
-                  <Profile username={profileUser} />
-                </S.LeftSideLayout>
-                <S.PageLayout>
-                  <Routes>
-                    <Route path="/" element={<Main />} />
-                    <Route path="/chat/list" element={<ChatList />} />
-                    <Route path="/game/list" element={<GameList />} />
-                    <Route path="/chat/:roomId" element={<ChatRoom />} />
-                    <Route path="/game/:gameId" element={<GameRoom />} />
-                    <Route path="/*" element={<NotFound />} />
-                  </Routes>
-                </S.PageLayout>
-              </S.HomeLayout>
-            </ProfileSetImgIsUpContext.Provider>
-          </ProfileImgIsUpContext.Provider>
+          <ListTabBar />
+          <S.HomeLayout>
+            <S.LeftSideLayout>
+              <Profile username={profileUser} />
+            </S.LeftSideLayout>
+            <S.PageLayout>
+              <Routes>
+                <Route path="/" element={<Main />} />
+                <Route path="/chat/list" element={<ChatList />} />
+                <Route path="/game/list" element={<GameList />} />
+                <Route path="/chat/:roomId" element={<ChatRoom />} />
+                <Route path="/game/:gameId" element={<GameRoom />} />
+                <Route path="/*" element={<NotFound />} />
+              </Routes>
+            </S.PageLayout>
+          </S.HomeLayout>
         </ProfileContext.Provider>
       </BrowserRouter>
     </S.AppLayout>


### PR DESCRIPTION
## 개요
- 아바타 불러오기 리액트 쿼리로 리팩토링

## 작업사항
- 호쏭님이 리액트 쿼리로 리팩토링한 부분
+ axios 반환 blob 객체로 url 생성해서 data 리턴
- 아바타 변경 시 기존 url revoke 처리
- 프로필 사진 1:1 비율 유지하게 변경

## 변경로직
- 파일리더 대신 `createObjectURL()` 사용해봤습니다!

## 코멘트
- 처음엔 잘 되길래 의아했는데, 곧 "간헐적"이란 부분을 찾았습니다..아마 파일리더로 처리하는 과정에서 비동기적으로 처리되어 미완성된 파일이 나와 안되는 부분이 생긴 것 같아요

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
