### PR TITLE
feat: 친구 추가 및 채팅 초대 #79

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ sketch# See https://help.github.com/articles/ignoring-files/ for more about igno
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vscode

--- a/src/components/leftSide/AddFriendBtn.tsx
+++ b/src/components/leftSide/AddFriendBtn.tsx
@@ -2,32 +2,35 @@ import { useEffect } from "react";
 import * as S from "./style";
 import { getSocket } from "socket/socket";
 import { ChatRoomResponse } from "socket/active/chatEventType";
+import { useQueryClient } from "@tanstack/react-query";
 
 export default function AddFriendBtn(props: { username: string }) {
   const socket = getSocket();
+  const queryCli = useQueryClient();
 
   const listener = (res: ChatRoomResponse) => {
     console.log(res);
     if (res.status === "approved") {
       alert("친구가 되었습니다");
+      queryCli.invalidateQueries(["profile", props.username]);
     } else if (res.status === "warning") {
       alert(res.detail);
     } else {
       console.log("addFriendResult", res);
     }
-  }
+  };
 
   useEffect(() => {
     socket.on("addFriendResult", listener);
     return () => {
       socket.off("addFriendResult", listener);
-    }
+    };
   }, []);
 
   const addBtnHandler = () => {
     socket.emit("addFriend", {
       username: props.username,
     });
-  }
+  };
   return <S.Button onClick={addBtnHandler}>친구 추가</S.Button>;
 }

--- a/src/components/leftSide/AddFriendBtn.tsx
+++ b/src/components/leftSide/AddFriendBtn.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import * as S from "./style";
+import { getSocket } from "socket/socket";
+import { ChatRoomResponse } from "socket/active/chatEventType";
+
+export default function AddFriendBtn(props: { username: string }) {
+  const socket = getSocket();
+
+  const listener = (res: ChatRoomResponse) => {
+    console.log(res);
+    if (res.status === "approved") {
+      alert("친구가 되었습니다");
+    } else if (res.status === "warning") {
+      alert(res.detail);
+    } else {
+      console.log("addFriendResult", res);
+    }
+  }
+
+  useEffect(() => {
+    socket.on("addFriendResult", listener);
+    return () => {
+      socket.off("addFriendResult", listener);
+    }
+  }, []);
+
+  const addBtnHandler = () => {
+    socket.emit("addFriend", {
+      username: props.username,
+    });
+  }
+  return <S.Button onClick={addBtnHandler}>친구 추가</S.Button>;
+}

--- a/src/components/leftSide/AddFriendBtn.tsx
+++ b/src/components/leftSide/AddFriendBtn.tsx
@@ -9,7 +9,6 @@ export default function AddFriendBtn(props: { username: string }) {
   const queryCli = useQueryClient();
 
   const listener = (res: ChatRoomResponse) => {
-    console.log(res);
     if (res.status === "approved") {
       alert("친구가 되었습니다");
       queryCli.invalidateQueries(["profile", props.username]);

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -8,6 +8,7 @@ import Modal from "modal/layout/Modal";
 import AvatarUploadModal from "modal/AvatarUploadModal";
 import { getAvatar } from "api/user";
 import { ProfileImgIsUpContext } from "hooks/context/ProfileContext";
+import AddFriendBtn from "./AddFriendBtn";
 
 interface userProps {
   user?: {
@@ -127,7 +128,7 @@ export function ProfileData(props: userProps) {
           </S.Button>
         )}
         {user && user.relation === "friend" && <S.Button>친구 삭제</S.Button>}
-        {user && user.relation === "others" && <S.Button>친구 추가</S.Button>}
+        {user && user.relation === "others" && <AddFriendBtn username={user.username} />}
       </S.ButtonBox>
     </S.ProfileLayout>
   );

--- a/src/components/rightSide/MyProfile.tsx
+++ b/src/components/rightSide/MyProfile.tsx
@@ -3,9 +3,24 @@ import { getProfile } from "api/user";
 import { getUsername } from "userAuth";
 import UserInfo from "./user/UserInfo";
 import * as S from "./style";
+import { getSocket } from "socket/socket";
+import { useEffect } from "react";
 
 export default function MyProfile() {
   const username = getUsername();
+  const socket = getSocket();
+
+  useEffect(() => {
+    socket.emit("subscribe", {
+      type: "chatInvitation",
+    });
+    return () => {
+      socket.emit("unsubscribe", {
+        type: "chatInvitation",
+      });
+    };
+  }, []);
+  
   const profileQuery = useQuery({
     queryKey: ["profile", username],
     queryFn: () => {

--- a/src/components/rightSide/MyProfile.tsx
+++ b/src/components/rightSide/MyProfile.tsx
@@ -2,8 +2,6 @@ import { useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getProfile, getAvatar } from "api/user";
 import { getUsername } from "userAuth";
-import { getSocket } from "socket/socket";
-import { useEffect } from "react";
 import useNotiModal from "hooks/useNotiModal";
 import { ProfileContext } from "hooks/context/ProfileContext";
 import { MyProfileLayout } from "./style";
@@ -11,20 +9,7 @@ import { UserItem } from "./user/style";
 import * as S from "./user/style";
 
 export default function MyProfile() {
-  const username = getUsername();
-  const socket = getSocket();
-
-  useEffect(() => {
-    socket.emit("subscribe", {
-      type: "chatInvitation",
-    });
-    return () => {
-      socket.emit("unsubscribe", {
-        type: "chatInvitation",
-      });
-    };
-  }, []);
-  
+  const username = getUsername();  
   const profileQuery = useQuery({
     queryKey: ["profile", username],
     queryFn: () => {
@@ -39,8 +24,7 @@ export default function MyProfile() {
     enabled: !!username,
   });
   const setProfileUser = useContext(ProfileContext);
-  const { showNotiModal, NotiModal, onOpenNotiModal, newNoti } = useNotiModal();
-
+  const { showNotiModal, NotiModal, onOpenNotiModal, newNoti } = useNotiModal(profileQuery.data.status);
   if (profileQuery.isLoading) return <UserItem />;
 
   return (

--- a/src/components/rightSide/MyProfile.tsx
+++ b/src/components/rightSide/MyProfile.tsx
@@ -24,7 +24,7 @@ export default function MyProfile() {
     enabled: !!username,
   });
   const setProfileUser = useContext(ProfileContext);
-  const { showNotiModal, NotiModal, onOpenNotiModal, newNoti } = useNotiModal(profileQuery.data.status);
+  const { showNotiModal, NotiModal, onOpenNotiModal, newNoti } = useNotiModal(profileQuery?.data?.status);
   if (profileQuery.isLoading) return <UserItem />;
 
   return (

--- a/src/components/rightSide/user/FriendList.tsx
+++ b/src/components/rightSide/user/FriendList.tsx
@@ -22,7 +22,7 @@ export default function FriendList(props: { listOf: string }) {
       setFriendList(res.list);
     }
   };
-  
+
   useEffect(() => {
     socket.emit("subscribe", {
       type: "friendList",
@@ -40,13 +40,12 @@ export default function FriendList(props: { listOf: string }) {
     <>
       {friendList.map((user) => {
         return (
-          <S.UserItem key={user.username}>
-            <UserInfo
-              listOf={props.listOf}
-              username={user.username}
-              subLine={user.status === "login" ? "🟣 온라인" : "⚫️ 오프라인"}
-            />
-          </S.UserItem>
+          <UserInfo
+            key={user.username}
+            listOf={props.listOf}
+            username={user.username}
+            subLine={user.status === "login" ? "🟣 온라인" : "⚫️ 오프라인"}
+          />
         );
       })}
     </>

--- a/src/components/rightSide/user/FriendList.tsx
+++ b/src/components/rightSide/user/FriendList.tsx
@@ -1,0 +1,54 @@
+import UserInfo from "./UserInfo";
+import * as S from "../style";
+import { useEffect, useState } from "react";
+import { getSocket } from "socket/socket";
+
+type FriendType = {
+  type: string;
+  list: FriendListType;
+};
+
+type FriendListType = {
+  username: string;
+  status: string;
+}[];
+
+export default function FriendList(props: { listOf: string }) {
+  const socket = getSocket();
+  const [friendList, setFriendList] = useState<FriendListType>([]);
+
+  const listener = (res: FriendType) => {
+    if (res.type === "friend") {
+      setFriendList(res.list);
+    }
+  };
+  
+  useEffect(() => {
+    socket.emit("subscribe", {
+      type: "friendList",
+    });
+    socket.on("message", listener);
+    return () => {
+      socket.emit("unsubscribe", {
+        type: "friendList",
+      });
+      socket.off("message", listener);
+    };
+  }, []);
+
+  return (
+    <>
+      {friendList.map((user) => {
+        return (
+          <S.UserItem key={user.username}>
+            <UserInfo
+              listOf={props.listOf}
+              username={user.username}
+              subLine={user.status === "login" ? "🟣 온라인" : "⚫️ 오프라인"}
+            />
+          </S.UserItem>
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/rightSide/user/InviteBtn.tsx
+++ b/src/components/rightSide/user/InviteBtn.tsx
@@ -1,0 +1,41 @@
+import { getSocket } from "socket/socket";
+import * as S from "./style";
+import { useEffect } from "react";
+
+type EvntResultType = {
+  status: string;
+  roomId: number;
+  detail: string;
+}
+
+type PropsType = {
+  roomId: number;
+  username: string;
+  close: () => void;
+}
+
+export default function InviteBtn(props: PropsType) {
+  const socket = getSocket();
+  const listener = (res: EvntResultType) => {
+    if (res.status === "error") {
+      alert(res.detail);
+    } else if (res.status === "approved") {
+      props.close();
+    }
+  }
+  useEffect(() => {
+    socket.on("inviteChatResult", listener);
+    return () => {
+      socket.off("inviteChatResult", listener);
+    }
+  }, []);
+
+  const inviteHandler = () => {
+    socket.emit("InviteChat", {
+      roomId: props.roomId,
+      username: props.username,
+    });
+  };
+
+  return <S.DropMenuItemBox onClick={inviteHandler}>채팅방 초대</S.DropMenuItemBox>;
+}

--- a/src/components/rightSide/user/InviteBtn.tsx
+++ b/src/components/rightSide/user/InviteBtn.tsx
@@ -31,7 +31,7 @@ export default function InviteBtn(props: PropsType) {
   }, []);
 
   const inviteHandler = () => {
-    socket.emit("InviteChat", {
+    socket.emit("inviteChat", {
       roomId: props.roomId,
       username: props.username,
     });

--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -12,6 +12,7 @@ export default function UserDropMenu(props: {
   targetOper?: string;
   targetMuted?: boolean;
   banned?: boolean;
+  subLine?: string;
 }) {
   const setProfileUser = useContext(ProfileContext);
   const roomId = Number(useParams().roomId);
@@ -23,6 +24,7 @@ export default function UserDropMenu(props: {
   const onKick = useOper("kick", roomId, props.targetUser, props.onClose);
   const onBan = useOper("ban", roomId, props.targetUser, props.onClose);
   const onUnban = useOper("unban", roomId, props.targetUser, props.onClose);
+  const isOnline = props.subLine?.split(" ")[1] === "온라인" ? true : false;
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
@@ -51,6 +53,7 @@ export default function UserDropMenu(props: {
         <S.DropMenuItemBox>게임 신청</S.DropMenuItemBox>
         {props.banned && <S.DropMenuItemBox onClick={onUnban}>입장 금지 해제</S.DropMenuItemBox>}
         {!props.banned &&
+          props.targetOper &&
           (myOper === "owner" || (myOper === "admin" && props.targetOper === "participant")) && (
             <>
               {props.targetMuted ? (
@@ -63,6 +66,7 @@ export default function UserDropMenu(props: {
             </>
           )}
         {!props.banned &&
+          props.targetOper &&
           myOper === "owner" &&
           (props.targetOper === "admin" ? (
             // TODO: 부방장 해제
@@ -70,9 +74,12 @@ export default function UserDropMenu(props: {
           ) : (
             <S.DropMenuItemBox onClick={onAppointAdmin}>부방장 지정</S.DropMenuItemBox>
           ))}
-        {(myOper === "owner" || myOper === "admin") && !props.targetOper && !props.banned && (
-          <InviteBtn roomId={roomId} username={props.targetUser} close={props.onClose} />
-        )}
+        {isOnline &&
+          (myOper === "owner" || myOper === "admin") &&
+          !props.targetOper &&
+          !props.banned && (
+            <InviteBtn roomId={roomId} username={props.targetUser} close={props.onClose} />
+          )}
       </S.DropMenuLayout>
     </>
   );

--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -70,7 +70,7 @@ export default function UserDropMenu(props: {
           ) : (
             <S.DropMenuItemBox onClick={onAppointAdmin}>부방장 지정</S.DropMenuItemBox>
           ))}
-        {roomId > 0 && !props.targetOper && !props.banned && (
+        {(myOper === "owner" || myOper === "admin") && !props.targetOper && !props.banned && (
           <InviteBtn roomId={roomId} username={props.targetUser} close={props.onClose} />
         )}
       </S.DropMenuLayout>

--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -80,7 +80,7 @@ export default function UserDropMenu(props: {
             <S.DropMenuItemBox onClick={onAppointAdmin}>부방장 지정</S.DropMenuItemBox>
           ))}
         {isOnline &&
-          (myOper === "owner" || myOper === "admin") &&
+          myOper && myOper !== "participant" &&
           !props.targetOper &&
           !props.banned && (
             <InviteBtn roomId={roomId} username={props.targetUser} close={props.onClose} />

--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -4,6 +4,7 @@ import { useOper, onProfile } from "hooks/useOper";
 import * as S from "./style";
 import { UserListContext } from "hooks/context/UserListContext";
 import { useParams } from "react-router-dom";
+import InviteBtn from "./InviteBtn";
 
 export default function UserDropMenu(props: {
   onClose: () => void;
@@ -69,6 +70,9 @@ export default function UserDropMenu(props: {
           ) : (
             <S.DropMenuItemBox onClick={onAppointAdmin}>부방장 지정</S.DropMenuItemBox>
           ))}
+        {roomId > 0 && !props.targetOper && !props.banned && (
+          <InviteBtn roomId={roomId} username={props.targetUser} close={props.onClose} />
+        )}
       </S.DropMenuLayout>
     </>
   );

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -69,6 +69,7 @@ export default function UserInfo(props: {
           targetOper={props.userOper}
           targetMuted={props.muted}
           banned={props.banned}
+          subLine={props.subLine}
         />
       )}
     </>

--- a/src/components/rightSide/user/UserList.tsx
+++ b/src/components/rightSide/user/UserList.tsx
@@ -5,6 +5,7 @@ import { BanListArray, UserListArray } from "socket/passive/chatRoomType";
 import { ProfileImgIsUpContext } from "hooks/context/ProfileContext";
 import UserInfo from "./UserInfo";
 import * as S from "../style";
+import FriendList from "./FriendList";
 
 type UserListCase =
   | { listOf: "friend" | "dm" | "player" | "observer" }
@@ -59,13 +60,18 @@ export default function UserList(props: UserListCase) {
             );
           })}
         {!["participant", "banned"].includes(props.listOf) && (
-          <S.UserItem>
-            <UserInfo
-              listOf={props.listOf}
-              username={profileQuery.data?.username}
-              subLine={profileQuery.data?.status === "login" ? "🟣 온라인" : "⚫️ 오프라인"}
-            />
-          </S.UserItem>
+          <>
+            {props.listOf === "friend" && <FriendList listOf={props.listOf} />}
+            {props.listOf === "dm" && (
+              <S.UserItem>
+                <UserInfo
+                  listOf={props.listOf}
+                  username={profileQuery.data?.username}
+                  subLine={profileQuery.data?.status === "login" ? "🟣 온라인" : "⚫️ 오프라인"}
+                />
+              </S.UserItem>
+            )}
+          </>
         )}
       </S.UserList>
     </S.UserListLayout>

--- a/src/components/rightSide/user/UserList.tsx
+++ b/src/components/rightSide/user/UserList.tsx
@@ -36,7 +36,7 @@ export default function UserList(props: UserListCase) {
                 listOf={props.listOf}
                 username={user.username}
                 userOper={user.owner ? "owner" : user.admin ? "admin" : "participant"}
-                subLine={user.login ? "🟣 온라인" : "⚫️ 오프라인"}
+                subLine={user.status === "login" ? "🟣 온라인" : "⚫️ 오프라인"}
                 muted={user.muted ? true : false}
               />
             );

--- a/src/hooks/useNotiModal.tsx
+++ b/src/hooks/useNotiModal.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
 import { getSocket } from "socket/socket";
 import Modal from "modal/layout/Modal";
 import NotificationModal from "modal/NotificationModal";
@@ -19,17 +18,21 @@ type InvitationType = {
 };
 
 export default function useNotiModal() {
-  const target = useLocation().pathname.split("/");
   const socket = getSocket();
   const [noti, setNoti] = useState<NotiType[]>([]);
   const [newNoti, setNewNoti] = useState(false);
   const [showNotiModal, setShowNotiModal] = useState(false);
-  const locPage = target[1];
-  const locRoom = target[2];
 
   const listener = (res: InvitationType) => {
     if (res.type === "chatInvitation") {
-      console.log(res);
+      setNoti((prev) => [
+        ...prev,
+        {
+          title: `${res.from} 님으로 부터 #${res.roomId} 채팅방에 초대 되었습니다.`,
+          chatId: res.roomId,
+          chatTitle: "초대된 ",
+        }
+      ])
       setNewNoti(true);
     }
   };
@@ -71,7 +74,7 @@ export default function useNotiModal() {
   return {
     showNotiModal,
     NotiModal: (
-      <Modal set={"noti"} setView={closeModalHandler}>
+      <Modal set={"noti"} setView={onOpenNotiModal}>
         <NotificationModal close={closeModalHandler} notiList={noti} />
       </Modal>
     ),

--- a/src/hooks/useNotiModal.tsx
+++ b/src/hooks/useNotiModal.tsx
@@ -17,7 +17,7 @@ type InvitationType = {
   from: string;
 };
 
-export default function useNotiModal() {
+export default function useNotiModal(status: string) {
   const socket = getSocket();
   const [noti, setNoti] = useState<NotiType[]>([]);
   const [newNoti, setNewNoti] = useState(false);
@@ -34,7 +34,7 @@ export default function useNotiModal() {
         },
       ]);
       setNewNoti(true);
-      setShowNotiModal(true);
+      if (status === "login") setShowNotiModal(true); // 게임 중 일때는 팝업 x
     }
   };
 
@@ -43,7 +43,7 @@ export default function useNotiModal() {
     return () => {
       socket.off("message", listener);
     };
-  }, []);
+  });
 
   const closeModalHandler = () => {
     setShowNotiModal(false);

--- a/src/hooks/useNotiModal.tsx
+++ b/src/hooks/useNotiModal.tsx
@@ -31,9 +31,10 @@ export default function useNotiModal() {
           title: `${res.from} 님으로 부터 #${res.roomId} 채팅방에 초대 되었습니다.`,
           chatId: res.roomId,
           chatTitle: "초대된 ",
-        }
-      ])
+        },
+      ]);
       setNewNoti(true);
+      setShowNotiModal(true);
     }
   };
 
@@ -41,23 +42,6 @@ export default function useNotiModal() {
     socket.on("message", listener);
     return () => {
       socket.off("message", listener);
-    };
-  }, []);
-
-  useEffect(() => {
-    socket.emit("subscribe", {
-      type: "chatInvitation",
-    });
-    socket.emit("subscribe", {
-      type: "gameInvitation",
-    });
-    return () => {
-      socket.emit("unsubscribe", {
-        type: "chatInvitation",
-      });
-      socket.emit("unsubscribe", {
-        type: "gameInvitation",
-      });
     };
   }, []);
 

--- a/src/index.css
+++ b/src/index.css
@@ -20,13 +20,14 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
+/* 이 부분이 제 작업물까지 영향을 줘서요 */
 * {
   /* 오페라 */
-  box-sizing: border-box;
+  /*box-sizing: border-box;*/
   /* 파이어폭스 */
-  -moz-box-sizing: border-box;
+  /*-moz-box-sizing: border-box;*/
   /* 웹킷 & 크롬 */
-  -webkit-box-sizing: border-box;
+  /*-webkit-box-sizing: border-box;*/
   /* iOS 사파리 기본 스타일 제거 */
   /* -webkit-appearance: none; */
 }

--- a/src/index.css
+++ b/src/index.css
@@ -20,14 +20,13 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
-/* 이 부분이 제 작업물까지 영향을 줘서요 */
 * {
   /* 오페라 */
-  /*box-sizing: border-box;*/
+  box-sizing: border-box;
   /* 파이어폭스 */
-  /*-moz-box-sizing: border-box;*/
+  -moz-box-sizing: border-box;
   /* 웹킷 & 크롬 */
-  /*-webkit-box-sizing: border-box;*/
+  -webkit-box-sizing: border-box;
   /* iOS 사파리 기본 스타일 제거 */
   /* -webkit-appearance: none; */
 }

--- a/src/modal/NotificationModal.tsx
+++ b/src/modal/NotificationModal.tsx
@@ -17,10 +17,6 @@ function NotificationModal(props: modalProps) {
       pathname: `/chat/${target[0]}`,
       search: `title=${target[1]}`,
     });
-    socket.emit("subscribe", {
-      type: "chatRoom",
-      roomId: Number(target[0]),
-    })
     props.close();
   };
 

--- a/src/modal/NotificationModal.tsx
+++ b/src/modal/NotificationModal.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { NotiType } from "hooks/useNotiModal";
 import * as S from "./layout/style";
+import { getSocket } from "socket/socket";
 
 type modalProps = {
   close: () => void;
@@ -9,12 +10,17 @@ type modalProps = {
 
 function NotificationModal(props: modalProps) {
   const navigate = useNavigate();
+  const socket = getSocket();
   const joinHandler = (e: React.MouseEvent<HTMLSpanElement>) => {
     const target = e.currentTarget.id.split("-");
     navigate({
       pathname: `/chat/${target[0]}`,
       search: `title=${target[1]}`,
     });
+    socket.emit("subscribe", {
+      type: "chatRoom",
+      roomId: Number(target[0]),
+    })
     props.close();
   };
 
@@ -25,16 +31,15 @@ function NotificationModal(props: modalProps) {
         {props.notiList.length > 0 ? (
           props.notiList.map((noti) => {
             return (
-              <>
+              <div key={noti.chatId}>
                 <S.Span
-                  key={noti.chatId}
                   onClick={joinHandler}
                   id={`${noti.chatId}-${noti.chatTitle}`}
                 >
                   {noti.title}
                 </S.Span>
                 <br />
-              </>
+              </div>
             );
           })
         ) : (

--- a/src/modal/NotificationModal.tsx
+++ b/src/modal/NotificationModal.tsx
@@ -26,7 +26,11 @@ function NotificationModal(props: modalProps) {
           props.notiList.map((noti) => {
             return (
               <>
-                <S.Span onClick={joinHandler} id={`${noti.chatId}-${noti.chatTitle}`}>
+                <S.Span
+                  key={noti.chatId}
+                  onClick={joinHandler}
+                  id={`${noti.chatId}-${noti.chatTitle}`}
+                >
                   {noti.title}
                 </S.Span>
                 <br />

--- a/src/modal/layout/style.tsx
+++ b/src/modal/layout/style.tsx
@@ -113,7 +113,7 @@ export const CreateRoomLayout = styled.div`
 `;
 
 export const Input = styled.input`
-  width: 50%;
+  width: 60%;
   padding: 12px 18px 12px;
   border: 1.5px solid lightgray;
   border-radius: 8px;

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -39,13 +39,25 @@ function Auth() {
     }
   };
 
+  const subListener = (res: {status: string; detail: string}) => {
+    if (res.status === "error") {
+      console.log("sub", res);
+    }
+  }
+
+  const unSubListener = (res: {status: string; detail: string}) => {
+    if (res.status === "error") {
+      console.log("unsub", res);
+    }
+  }
+
   useEffect(() => {
-    socket.on("subscribeResult", (data) => console.log(data));
-    socket.on("unsubscribeResult", (data) => console.log(data));
+    socket.on("subscribeResult", subListener);
+    socket.on("unsubscribeResult", unSubListener);
     socket.on("error", errorListener);
     return () => {
-      socket.off("subscribeResult", (data) => console.log(data));
-      socket.off("unsubscribeResult", (data) => console.log(data));
+      socket.off("subscribeResult", subListener);
+      socket.off("unsubscribeResult", unSubListener);
       socket.off("error", errorListener);
     };
   }, []);

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -35,12 +35,14 @@ function Auth() {
   };
 
   const subListener = (res: {status: string; type: string}) => {
+    console.log("구독", res.type);
     if (res.status === "error") {
       console.log("sub", res);
     }
   }
 
   const unSubListener = (res: {status: string; type: string}) => {
+    console.log("구독해제", res.type);
     if (res.status === "error") {
       console.log("unsub", res);
     }

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -34,13 +34,15 @@ function Auth() {
     }
   };
 
-  const subListener = (res: {status: string; detail: string}) => {
+  const subListener = (res: {status: string; type: string}) => {
+    console.log("sub", res.type);
     if (res.status === "error") {
       console.log("sub", res);
     }
   }
 
-  const unSubListener = (res: {status: string; detail: string}) => {
+  const unSubListener = (res: {status: string; type: string}) => {
+    console.log("unsub", res.type);
     if (res.status === "error") {
       console.log("unsub", res);
     }
@@ -54,6 +56,17 @@ function Auth() {
       socket.off("subscribeResult", subListener);
       socket.off("unsubscribeResult", unSubListener);
       socket.off("error", errorListener);
+    };
+  }, []);
+
+  useEffect(() => {
+    socket.emit("subscribe", {
+      type: "chatInvitation",
+    });
+    return () => {
+      socket.emit("unsubscribe", {
+        type: "chatInvitation",
+      });
     };
   }, []);
 

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -35,14 +35,12 @@ function Auth() {
   };
 
   const subListener = (res: {status: string; type: string}) => {
-    console.log("sub", res.type);
     if (res.status === "error") {
       console.log("sub", res);
     }
   }
 
   const unSubListener = (res: {status: string; type: string}) => {
-    console.log("unsub", res.type);
     if (res.status === "error") {
       console.log("unsub", res);
     }

--- a/src/pages/auth/chat/list/JoinBtn.tsx
+++ b/src/pages/auth/chat/list/JoinBtn.tsx
@@ -26,9 +26,11 @@ export default function JoinChatRoom(props: PropsType) {
       console.log(res);
     } else if (res.status === "warning") {
       if (showModal) {
-        setNotice(res.detail);
+        if (res.detail === "밴 당하셨습니다.") setNotice("입장이 거부된 방입니다.");
+        else setNotice(res.detail);
       } else {
-        alert(res.detail);
+        if (res.detail === "밴 당하셨습니다.") alert("입장이 거부된 방입니다.");
+        else alert(res.detail);
       }
     } else {
       navigate({

--- a/src/pages/auth/chat/list/JoinBtn.tsx
+++ b/src/pages/auth/chat/list/JoinBtn.tsx
@@ -22,13 +22,14 @@ export default function JoinChatRoom(props: PropsType) {
 
   const listner = (res: ChatRoomResponse) => {
     if (res.roomId !== props.roomId) return;
-    console.log("참가 결과", res);
     if (res.status === "error") {
       console.log(res);
     } else if (res.status === "warning") {
-      // TODO: 여기도 모달로?
-      if (res.detail === "밴 당하셨습니다.") alert("입장이 거부된 방입니다.");
-      setNotice(res.detail);
+      if (showModal) {
+        setNotice(res.detail);
+      } else {
+        alert(res.detail);
+      }
     } else {
       navigate({
         pathname: `/chat/${res.roomId}`,
@@ -42,7 +43,7 @@ export default function JoinChatRoom(props: PropsType) {
     return () => {
       socket.off("joinChatRoomResult", listner);
     };
-  }, []);
+  }, [showModal]);
 
   const showModalHandler = () => {
     setShowModal(true);
@@ -50,6 +51,7 @@ export default function JoinChatRoom(props: PropsType) {
 
   const closeModalHandler = () => {
     setShowModal(false);
+    if (notice) setNotice("")
   };
 
   function joinHandler() {

--- a/src/pages/auth/chat/room/ChatRoom.tsx
+++ b/src/pages/auth/chat/room/ChatRoom.tsx
@@ -53,7 +53,7 @@ export default function ChatRoom() {
     return () => {
       socket.emit("unsubscribe", { type: "chatRoom", roomId: Number(roomId) });
     };
-  }, []);
+  }, [roomId]);
 
   return (
     <>

--- a/src/pages/auth/chat/room/ChatRoom.tsx
+++ b/src/pages/auth/chat/room/ChatRoom.tsx
@@ -21,20 +21,13 @@ export default function ChatRoom() {
   const [target, setTarget] = useSearchParams();
   const [participant, setParticipant] = useState<T.UserListArray | null>(null);
   const [banned, setBanned] = useState<T.BanListArray | null>(null);
-  const [initialChat, setInitialChat] = useState<T.ChatData[]>();
   const myOper = useRef("participant");
 
   function handleChatRoom(res: T.ChatData | T.HistoryData | T.ChatRoomData | T.AffectedData) {
     // TEST: 채팅방 내 전체 이벤트 리스너
     if (res.roomId !== Number(roomId) || res.type === "chat") return;
     console.log("채팅방", res);
-    if (res.type === "history") {
-      const historyChat: T.ChatData[] = [];
-      res.list.map((chat) => {
-        historyChat.push({ ...chat, type: "chat", roomId: Number(roomId) });
-      });
-      setInitialChat(historyChat);
-    } else if (res.type === "chatRoom") {
+    if (res.type === "chatRoom") {
       const myRoomInfo = res.userList.filter((user) => user.username === getUsername())[0];
       if (myRoomInfo?.owner) myOper.current = "owner";
       else if (myRoomInfo?.admin) myOper.current = "admin";
@@ -73,7 +66,7 @@ export default function ChatRoom() {
           <ExitBtn room={Number(roomId)} />
         </S.HeaderBox>
         <S.MainBox>
-          {initialChat && <Screen room={Number(roomId)} initialChat={initialChat} />}
+          <Screen room={Number(roomId)} />
           <SendBtn room={Number(roomId)} />
         </S.MainBox>
       </S.PageLayout>

--- a/src/pages/auth/chat/room/Screen.tsx
+++ b/src/pages/auth/chat/room/Screen.tsx
@@ -3,15 +3,23 @@ import { ChatData } from "socket/passive/chatRoomType";
 import { getSocket } from "socket/socket";
 import * as S from "./style";
 
-export default function Screen(props: { room: number; initialChat: ChatData[] }) {
+export default function Screen(props: { room: number }) {
   const socket = getSocket();
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [screen, setScreen] = useState(props.initialChat);
+  const [screen, setScreen] = useState<ChatData[]>([]);
   let keyCnt = 0;
 
   function listener(res: ChatData) {
     if (res.roomId !== Number(props.room)) return;
-    if (res.type === "chat") setScreen((prevScreen) => [...prevScreen, res]);
+    if (res.type === "chat") {
+      setScreen((prevScreen) => [...prevScreen, res])
+    } else if (res.type === "history") {
+      const historyChat: ChatData[] = [];
+      res.list?.map((chat) => {
+        historyChat.push({ ...chat, type: "chat", roomId: props.room });
+      });
+      setScreen(historyChat);
+    }
   }
 
   useEffect(() => {

--- a/src/pages/auth/chat/room/style.tsx
+++ b/src/pages/auth/chat/room/style.tsx
@@ -62,7 +62,7 @@ export const SendBtn = styled.button`
 `;
 
 export const Input = styled.input`
-  width: 80%;
+  width: 90%;
   padding: 12px 18px 12px;
   border: 1.5px solid lightgray;
   border-radius: 8px;

--- a/src/pages/unauth/signIn/style.tsx
+++ b/src/pages/unauth/signIn/style.tsx
@@ -36,7 +36,7 @@ export const FormLogo = styled.div`
 `
 
 export const Input = styled.input`
-  width: 55%;
+  width: 65%;
   padding: 12px 18px 12px;
   border: 1.5px solid lightgray;
   border-radius: 8px;

--- a/src/pages/unauth/signUp/style.tsx
+++ b/src/pages/unauth/signUp/style.tsx
@@ -40,7 +40,7 @@ export const Button1 = styled(Button)`
 `
 
 export const Input = styled.input`
-  width: 55%;
+  width: 65%;
   padding: 12px 18px 12px;
   border: 1.5px solid lightgray;
   border-radius: 8px;

--- a/src/socket/passive/chatRoomType.ts
+++ b/src/socket/passive/chatRoomType.ts
@@ -31,7 +31,7 @@ export type UserListArray = {
   owner: boolean;
   admin: boolean;
   muted: boolean;
-  login: boolean;
+  status: string;
 }[];
 
 export type BanListArray = {

--- a/src/socket/passive/chatRoomType.ts
+++ b/src/socket/passive/chatRoomType.ts
@@ -4,6 +4,7 @@ export type ChatData = {
   status: "plain" | "notice";
   from: string;
   content: string;
+  list?: HistoryArray;
 };
 
 export type HistoryData = {


### PR DESCRIPTION
## 개요
- 친구 추가, 리스트
- 채팅 초대, 알림

## 작업사항
- 친구추가는 구독 방식(친구 취소 기능 x)
- 채팅초대는 채팅방 안에서 친구에게 사용하는 기능
  - 해당 채팅 방에 방장, 관리자만 사용할 수 있는 기능
  - 수락여부 없이 채팅에 참여
- 채팅초대되면 알림 발생 -> 알림 누르면 해당 채팅방으로 이동


<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
