### PR TITLE
feat: dm 기능 구현 #76

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,5 +9,6 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <div id="modal-root"></div>
   </body>
 </html>

--- a/src/api/dm.ts
+++ b/src/api/dm.ts
@@ -1,0 +1,11 @@
+import axios from "axios";
+
+export async function getDmList() {
+  try {
+    const res = await axios.get("/dm/list");
+    return res.data;
+  } catch (err: unknown) {
+    console.error(err);
+    return null;
+  }
+}

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -1,13 +1,13 @@
-import { useContext, useEffect, useState } from "react";
-import * as S from "./style";
+import { useContext, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { getAvatar } from "api/user";
 import { distroyAuth, getUsername } from "userAuth";
 import { AuthContext } from "hooks/context/AuthContext";
 import { disconnectSocket } from "socket/socket";
-import { useNavigate } from "react-router-dom";
 import Modal from "modal/layout/Modal";
 import AvatarUploadModal from "modal/AvatarUploadModal";
-import { getAvatar } from "api/user";
-import { useQuery } from "@tanstack/react-query";
+import * as S from "./style";
 
 interface userProps {
   user?: {
@@ -46,8 +46,6 @@ export function ProfileData(props: userProps) {
     enabled: !!props.user,
   });
 
-  if (avatarQuery.isLoading) console.log("loading");
-
   const openModalHandler = () => {
     setShowModal(true);
   };
@@ -68,11 +66,15 @@ export function ProfileData(props: userProps) {
         </Modal>
       )}
       <S.Title>프로필</S.Title>
-      <S.ProfileImg
-        me={myProfile}
-        src={String(avatarQuery.data)}
-        onClick={myProfile ? openModalHandler : undefined}
-      />
+      {avatarQuery.isLoading ? (
+        <S.LoadingImg />
+      ) : (
+        <S.ProfileImg
+          me={myProfile}
+          src={String(avatarQuery.data)}
+          onClick={myProfile ? openModalHandler : undefined}
+        />
+      )}
       <S.InfoWrapper>
         <S.InfoLabel>
           닉네임

--- a/src/components/leftSide/style.tsx
+++ b/src/components/leftSide/style.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { darkGray } from "style/color";
 import * as font from "style/font";
 import * as button from "style/button";
 
@@ -18,6 +19,16 @@ export const Title = styled.h2`
 /*
  *      Profile Item
  */
+
+export const LoadingImg = styled.img<{ clickable?: boolean }>`
+  width: 100px;
+  height: 100px;
+  border-radius: 100%;
+  flex-shrink: 0;
+  margin: 20px auto;
+
+  background-color: ${darkGray};
+`;
 
 export const ProfileImg = styled.img<{ me: boolean }>`
   width: 100px;

--- a/src/components/rightSide/FriendAndDmBar.tsx
+++ b/src/components/rightSide/FriendAndDmBar.tsx
@@ -22,7 +22,10 @@ export default function FriendAndDmBar() {
 
   function handleClick(e: React.MouseEvent<HTMLDivElement>) {
     const id = e.currentTarget.id;
-    if (id === "dm") setIsNewDm(false);
+    if (id === "dm") {
+      queryClient.invalidateQueries(["list", "dm"]);
+      setIsNewDm(false);
+    }
     setIsOpen(id as "friend" | "dm" | "");
     if (id === isOpen) setIsOpen("");
   }
@@ -30,8 +33,9 @@ export default function FriendAndDmBar() {
   function handleList(res: T.DmList) {
     if (res.type === "dmList") {
       console.log("dm 리스트", res, "현재 열림:", isOpen);
-      // if (isOpen !== "dm") setIsNewDm(true);
-      queryClient.invalidateQueries(["list", "dm"]);
+      if (isOpen !== "dm") setIsNewDm(true);
+      // TODO: dm 모달 안띄워져 있을때 하기!
+      // queryClient.invalidateQueries(["list", "dm"]);
     }
   }
 

--- a/src/components/rightSide/FriendAndDmBar.tsx
+++ b/src/components/rightSide/FriendAndDmBar.tsx
@@ -22,6 +22,7 @@ export default function FriendAndDmBar() {
     if (res.type === "dmList") {
       // TEST: DM 리스트 출력
       console.log("dm리스트", res);
+      if (isOpen !== "dm") setIsNewDm(true);
       setDmList(res.list);
     }
   }

--- a/src/components/rightSide/FriendAndDmBar.tsx
+++ b/src/components/rightSide/FriendAndDmBar.tsx
@@ -8,7 +8,7 @@ export default function FriendAndDmBar() {
   const [isOpen, setIsOpen] = useState<"friend" | "dm" | "">("");
   const [isNewDm, setIsNewDm] = useState(true);
   const socket = getSocket();
-  const dmList = useRef<T.DmListArray>([]);
+  const [dmList, setDmList] = useState<T.DmListArray>([]);
   // TODO: dm 이벤트에 따라 set 함수 사용
 
   function handleClick(e: React.MouseEvent<HTMLDivElement>) {
@@ -22,7 +22,7 @@ export default function FriendAndDmBar() {
     if (res.type === "dmList") {
       // TEST: DM 리스트 출력
       console.log("dm리스트", res);
-      dmList.current = res.list;
+      setDmList(res.list);
     }
   }
 
@@ -56,7 +56,7 @@ export default function FriendAndDmBar() {
       </S.BarLayout>
       {isOpen &&
         (isOpen === "dm" ? (
-          <UserList listOf={isOpen} list={dmList.current} />
+          <UserList listOf={isOpen} list={dmList} />
         ) : (
           <UserList listOf={isOpen} />
         ))}

--- a/src/components/rightSide/FriendAndDmBar.tsx
+++ b/src/components/rightSide/FriendAndDmBar.tsx
@@ -5,11 +5,10 @@ import * as T from "socket/passive/friendDmListType";
 import * as S from "./style";
 
 export default function FriendAndDmBar() {
+  const socket = getSocket();
   const [isOpen, setIsOpen] = useState<"friend" | "dm" | "">("");
   const [isNewDm, setIsNewDm] = useState(true);
-  const socket = getSocket();
   const [dmList, setDmList] = useState<T.DmListArray>([]);
-  // TODO: dm 이벤트에 따라 set 함수 사용
 
   function handleClick(e: React.MouseEvent<HTMLDivElement>) {
     const id = e.currentTarget.id;
@@ -32,7 +31,7 @@ export default function FriendAndDmBar() {
     return () => {
       socket.off("message", handleList);
     };
-  });
+  }, []);
 
   useEffect(() => {
     socket.emit("subscribe", {

--- a/src/components/rightSide/FriendAndDmBar.tsx
+++ b/src/components/rightSide/FriendAndDmBar.tsx
@@ -23,19 +23,19 @@ export default function FriendAndDmBar() {
   function handleClick(e: React.MouseEvent<HTMLDivElement>) {
     const id = e.currentTarget.id;
     if (id === "dm") {
-      queryClient.invalidateQueries(["list", "dm"]);
       setIsNewDm(false);
+      queryClient.invalidateQueries(["list", "dm"]);
     }
-    setIsOpen(id as "friend" | "dm" | "");
-    if (id === isOpen) setIsOpen("");
+    id === isOpen ? setIsOpen("") : setIsOpen(id as "friend" | "dm" | "");
   }
 
   function handleList(res: T.DmList) {
-    if (res.type === "dmList") {
-      console.log("dm 리스트", res, "현재 열림:", isOpen);
-      if (isOpen !== "dm") setIsNewDm(true);
-      // TODO: dm 모달 안띄워져 있을때 하기!
-      // queryClient.invalidateQueries(["list", "dm"]);
+    if (res.type !== "dmList") return;
+    // TEST: 테스트중
+    console.log("dm 리스트", res, "현재 열림:", isOpen);
+    const dmNode = document.getElementById("modal-root")?.firstChild;
+    if (!dmNode) {
+      isOpen === "dm" ? queryClient.invalidateQueries(["list", "dm"]) : setIsNewDm(true);
     }
   }
 
@@ -44,7 +44,7 @@ export default function FriendAndDmBar() {
     return () => {
       socket.off("message", handleList);
     };
-  }, []);
+  }, [isOpen]);
 
   useEffect(() => {
     socket.emit("subscribe", {

--- a/src/components/rightSide/FriendAndDmBar.tsx
+++ b/src/components/rightSide/FriendAndDmBar.tsx
@@ -1,10 +1,14 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import UserList from "./user/UserList";
+import { getSocket } from "socket/socket";
+import * as T from "socket/passive/friendDmListType";
 import * as S from "./style";
 
 export default function FriendAndDmBar() {
   const [isOpen, setIsOpen] = useState<"friend" | "dm" | "">("");
   const [isNewDm, setIsNewDm] = useState(true);
+  const socket = getSocket();
+  const dmList = useRef<T.DmListArray>([]);
   // TODO: dm 이벤트에 따라 set 함수 사용
 
   function handleClick(e: React.MouseEvent<HTMLDivElement>) {
@@ -13,6 +17,32 @@ export default function FriendAndDmBar() {
     if (id === "friend" || id === "dm") setIsOpen(id);
     if (id === isOpen) setIsOpen("");
   }
+
+  function handleList(res: T.DmList) {
+    if (res.type === "dmList") {
+      // TEST: DM 리스트 출력
+      console.log("dm리스트", res);
+      dmList.current = res.list;
+    }
+  }
+
+  useEffect(() => {
+    socket.on("message", handleList);
+    return () => {
+      socket.off("message", handleList);
+    };
+  });
+
+  useEffect(() => {
+    socket.emit("subscribe", {
+      type: "dmList",
+    });
+    return () => {
+      socket.emit("unsubscribe", {
+        type: "dmList",
+      });
+    };
+  }, []);
 
   return (
     <>
@@ -24,7 +54,12 @@ export default function FriendAndDmBar() {
           {isNewDm ? <S.NewDmIcon /> : <S.DmIcon />}
         </S.IconWrapper>
       </S.BarLayout>
-      {isOpen && <UserList listOf={isOpen} />}
+      {isOpen &&
+        (isOpen === "dm" ? (
+          <UserList listOf={isOpen} list={dmList.current} />
+        ) : (
+          <UserList listOf={isOpen} />
+        ))}
     </>
   );
 }

--- a/src/components/rightSide/MyProfile.tsx
+++ b/src/components/rightSide/MyProfile.tsx
@@ -1,8 +1,11 @@
+import { useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getProfile } from "api/user";
 import { getUsername } from "userAuth";
-import UserInfo from "./user/UserInfo";
-import * as S from "./style";
+import useNotiModal from "hooks/useNotiModal";
+import { ProfileContext } from "hooks/context/ProfileContext";
+import { MyProfileLayout, UserItem } from "./style";
+import * as S from "./user/style";
 
 export default function MyProfile() {
   const username = getUsername();
@@ -12,14 +15,38 @@ export default function MyProfile() {
       return getProfile(username);
     },
   });
+  const setProfileUser = useContext(ProfileContext);
+  const { showNotiModal, NotiModal, onOpenNotiModal, newNoti } = useNotiModal();
 
-  if (profileQuery.isLoading) return <S.UserItem />;
+  if (profileQuery.isLoading) return <UserItem />;
 
   return (
-    <S.MyProfileLayout>
-      <S.UserItem>
-        <UserInfo username={profileQuery?.data?.username} subLine="🟣 온라인" />
-      </S.UserItem>
-    </S.MyProfileLayout>
+    <MyProfileLayout>
+      <UserItem>
+        {showNotiModal && NotiModal}
+        <S.TmpImg
+          clickable
+          // src={img} TODO: 로그인한 유저 프로필 이미지 불러오기 필요
+          onClick={() => {
+            setProfileUser && setProfileUser(username);
+          }}
+        />
+        <S.UserInfoText
+          clickable
+          onClick={() => {
+            setProfileUser && setProfileUser(username);
+          }}
+        >
+          {profileQuery?.data?.username}
+          <br />
+          🟣 온라인
+        </S.UserInfoText>
+        {newNoti ? (
+          <S.NewNotiIcon onClick={onOpenNotiModal} />
+        ) : (
+          <S.EmptyNotiIcon onClick={onOpenNotiModal} />
+        )}
+      </UserItem>
+    </MyProfileLayout>
   );
 }

--- a/src/components/rightSide/MyProfile.tsx
+++ b/src/components/rightSide/MyProfile.tsx
@@ -4,7 +4,8 @@ import { getProfile } from "api/user";
 import { getUsername } from "userAuth";
 import useNotiModal from "hooks/useNotiModal";
 import { ProfileContext } from "hooks/context/ProfileContext";
-import { MyProfileLayout, UserItem } from "./style";
+import { MyProfileLayout } from "./style";
+import { UserItem } from "./user/style";
 import * as S from "./user/style";
 
 export default function MyProfile() {

--- a/src/components/rightSide/MyProfile.tsx
+++ b/src/components/rightSide/MyProfile.tsx
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { getProfile } from "api/user";
+import { getProfile, getAvatar } from "api/user";
 import { getUsername } from "userAuth";
 import useNotiModal from "hooks/useNotiModal";
 import { ProfileContext } from "hooks/context/ProfileContext";
@@ -16,6 +16,13 @@ export default function MyProfile() {
       return getProfile(username);
     },
   });
+  const avatarQuery = useQuery({
+    queryKey: ["avatar", `${username}`],
+    queryFn: () => {
+      if (username) return getAvatar(username);
+    },
+    enabled: !!username,
+  });
   const setProfileUser = useContext(ProfileContext);
   const { showNotiModal, NotiModal, onOpenNotiModal, newNoti } = useNotiModal();
 
@@ -25,13 +32,17 @@ export default function MyProfile() {
     <MyProfileLayout>
       <UserItem>
         {showNotiModal && NotiModal}
-        <S.TmpImg
-          clickable
-          // src={img} TODO: 로그인한 유저 프로필 이미지 불러오기 필요
-          onClick={() => {
-            setProfileUser && setProfileUser(username);
-          }}
-        />
+        {avatarQuery.isLoading ? (
+          <S.LoadingImg />
+        ) : (
+          <S.ProfileImg
+            clickable
+            src={String(avatarQuery.data)}
+            onClick={() => {
+              setProfileUser && setProfileUser(username);
+            }}
+          />
+        )}
         <S.UserInfoText
           clickable
           onClick={() => {

--- a/src/components/rightSide/style.tsx
+++ b/src/components/rightSide/style.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { FaUserFriends } from "react-icons/fa";
+import { FiUsers } from "react-icons/fi";
 import { BsEnvelope, BsEnvelopeExclamation } from "react-icons/bs";
 import { darkMain } from "style/color";
 
@@ -40,7 +40,7 @@ export const IconWrapper = styled.div`
   cursor: pointer;
 `;
 
-export const FriendIcon = styled(FaUserFriends)`
+export const FriendIcon = styled(FiUsers)`
   width: 20px;
   height: 20px;
   pointer-events: none;

--- a/src/components/rightSide/style.tsx
+++ b/src/components/rightSide/style.tsx
@@ -82,10 +82,3 @@ export const UserList = styled.ul`
 
   overflow: auto;
 `;
-
-export const UserItem = styled.li`
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  list-style-type: none;
-`;

--- a/src/components/rightSide/style.tsx
+++ b/src/components/rightSide/style.tsx
@@ -66,10 +66,11 @@ export const NewDmIcon = styled(BsEnvelopeExclamation)`
 export const UserListLayout = styled.div`
   display: flex;
   flex-direction: column;
-  flex: 1 0 auto;
+  flex: 1 1 0;
 
   padding: 8px 5px 8px 10px;
   border-bottom: 0.5px solid;
+  overflow: auto;
 `;
 
 export const UserList = styled.ul`

--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -23,6 +23,10 @@ export default function UserDropMenu(props: {
   const onBan = useOper("ban", roomId, props.targetUser, props.onClose);
   const onUnban = useOper("unban", roomId, props.targetUser, props.onClose);
 
+  function handleDm() {
+    // TODO: DM방 모달 띄우기 구현
+  }
+
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
       if (dropRef.current && e.target instanceof Element && !dropRef.current.contains(e.target))
@@ -46,10 +50,11 @@ export default function UserDropMenu(props: {
         >
           프로필
         </S.DropMenuItemBox>
-        <S.DropMenuItemBox>DM 보내기</S.DropMenuItemBox>
+        <S.DropMenuItemBox onClick={handleDm}>DM 보내기</S.DropMenuItemBox>
         <S.DropMenuItemBox>게임 신청</S.DropMenuItemBox>
         {props.banned && <S.DropMenuItemBox onClick={onUnban}>입장 금지 해제</S.DropMenuItemBox>}
         {!props.banned &&
+          props.targetOper &&
           (myOper === "owner" || (myOper === "admin" && props.targetOper === "participant")) && (
             <>
               {props.targetMuted ? (
@@ -62,6 +67,7 @@ export default function UserDropMenu(props: {
             </>
           )}
         {!props.banned &&
+          props.targetOper &&
           myOper === "owner" &&
           (props.targetOper === "admin" ? (
             // TODO: 부방장 해제

--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useRef, useContext } from "react";
+import { useEffect, useRef, useContext, useState } from "react";
+import { useParams } from "react-router-dom";
 import { ProfileContext } from "hooks/context/ProfileContext";
 import { useOper, onProfile } from "hooks/useOper";
-import * as S from "./style";
 import { UserListContext } from "hooks/context/UserListContext";
-import { useParams } from "react-router-dom";
+import * as S from "./style";
 
 export default function UserDropMenu(props: {
   onClose: () => void;
+  onDmOpen: () => void;
   targetUser: string;
   targetOper?: string;
   targetMuted?: boolean;
@@ -24,7 +25,8 @@ export default function UserDropMenu(props: {
   const onUnban = useOper("unban", roomId, props.targetUser, props.onClose);
 
   function handleDm() {
-    // TODO: DM방 모달 띄우기 구현
+    props.onDmOpen();
+    props.onClose();
   }
 
   useEffect(() => {
@@ -70,7 +72,6 @@ export default function UserDropMenu(props: {
           props.targetOper &&
           myOper === "owner" &&
           (props.targetOper === "admin" ? (
-            // TODO: 부방장 해제
             <S.DropMenuItemBox onClick={onDismissAdmin}>부방장 해제</S.DropMenuItemBox>
           ) : (
             <S.DropMenuItemBox onClick={onAppointAdmin}>부방장 지정</S.DropMenuItemBox>

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -32,15 +32,13 @@ export default function UserInfo({
     username: username,
   });
   const { Modal, isOpen, onOpen, onClose } = useModal();
-  const node = document.getElementById(username + "info");
-  const { isMouseEnter, onLeave } = useMouseOver({ listOf, node });
+  const { isMouseEnter, onLeave } = useMouseOver({ listOf, user: username });
 
   const avatarQuery = useQuery({
     queryKey: ["avatar", `${username}`],
     queryFn: () => {
       if (username) return getAvatar(username);
     },
-    enabled: !!username,
   });
 
   // const socket = getSocket();
@@ -102,7 +100,7 @@ export default function UserInfo({
         />
       )}
       {isOpen && (
-        <Modal>
+        <Modal key={username}>
           <DmModal targetUser={username} onClose={onClose} />
         </Modal>
       )}

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -41,7 +41,14 @@ export default function UserInfo(props: {
 
   return (
     <>
-      {dmIsOpen && <DmModal targetUser={props.username} onClose={setDmIsOpen} />}
+      {dmIsOpen && (
+        <DmModal
+          targetUser={props.username}
+          onClose={() => {
+            setDmIsOpen(false);
+          }}
+        />
+      )}
       <S.TmpImg
         src={img}
         clickable={props.listOf === "dm"}

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -39,29 +39,19 @@ export default function UserInfo(props: {
     getAvatarHandler();
   }, [profileImgIsUp]);
 
+  function onDmOpen() {
+    setDmIsOpen(true);
+  }
+
+  function onDmClose() {
+    setDmIsOpen(false);
+  }
+
   return (
     <>
-      {dmIsOpen && (
-        <DmModal
-          targetUser={props.username}
-          onClose={() => {
-            setDmIsOpen(false);
-          }}
-        />
-      )}
-      <S.TmpImg
-        src={img}
-        clickable={props.listOf === "dm"}
-        onClick={() => {
-          setDmIsOpen(true);
-        }}
-      />
-      <S.UserInfoText
-        clickable={props.listOf === "dm"}
-        onClick={() => {
-          setDmIsOpen(true);
-        }}
-      >
+      {dmIsOpen && <DmModal targetUser={props.username} onClose={onDmClose} />}
+      <S.TmpImg src={img} clickable={props.listOf === "dm"} onClick={onDmOpen} />
+      <S.UserInfoText clickable={props.listOf === "dm"} onClick={onDmOpen}>
         {props.username}{" "}
         {props.userOper === "owner" ? "👑" : props.userOper === "admin" ? "🎩" : ""}
         {props.muted ? " 🤐" : ""}
@@ -72,6 +62,7 @@ export default function UserInfo(props: {
       {dropIsOpen && (
         <UserDropMenu
           onClose={onDropClose}
+          onDmOpen={onDmOpen}
           targetUser={props.username}
           targetOper={props.userOper}
           targetMuted={props.muted}

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -1,10 +1,5 @@
-import { useContext, useEffect, useState } from "react";
-import { ProfileImgIsUpContext } from "hooks/context/ProfileContext";
+import { useQuery } from "@tanstack/react-query";
 import { getAvatar } from "api/user";
-import { useContext, useState } from "react";
-import { ProfileContext } from "hooks/context/ProfileContext";
-import UserDropMenu from "./UserDropMenu";
-import useNotiModal from "hooks/useNotiModal";
 import useDropModal from "hooks/useDropModal";
 import useModal from "hooks/useModal";
 import useMouseOver from "hooks/useMouseOver";
@@ -12,7 +7,6 @@ import DmModal from "modal/DmModal";
 import UserDropMenu from "./UserDropMenu";
 import { getUsername } from "userAuth";
 // import { getSocket } from "socket/socket";
-import { useQuery } from "@tanstack/react-query";
 import * as S from "./style";
 
 type UserInfoProps = {
@@ -22,7 +16,6 @@ type UserInfoProps = {
   subLine: string;
   muted?: boolean;
   banned?: boolean;
-  onClickProfile?: () => void;
 };
 
 export default function UserInfo({
@@ -32,7 +25,6 @@ export default function UserInfo({
   subLine,
   muted,
   banned,
-  onClickProfile,
 }: UserInfoProps) {
   const me = getUsername() === username;
   const { onDropOpen, onDropClose, dropIsOpen } = useDropModal({
@@ -87,7 +79,7 @@ export default function UserInfo({
       onClick={onDmOpen}
     >
       {avatarQuery.isLoading ? (
-        <S.TmpImg />
+        <S.LoadingImg />
       ) : (
         <S.ProfileImg src={String(avatarQuery.data)} clickable={listOf === "dm"} />
       )}

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -4,8 +4,9 @@ import UserDropMenu from "./UserDropMenu";
 import useDropModal from "hooks/useDropModal";
 import { getUsername } from "userAuth";
 import { getAvatar } from "api/user";
-import * as S from "./style";
 import DmModal from "modal/DmModal";
+// import { getSocket } from "socket/socket";
+import * as S from "./style";
 
 export default function UserInfo(props: {
   listOf?: string;
@@ -24,6 +25,7 @@ export default function UserInfo(props: {
   });
   const [dmIsOpen, setDmIsOpen] = useState(false);
   const [img, setImg] = useState("");
+  const [isMouseEnter, setIsMouseEnter] = useState(false);
 
   useEffect(() => {
     const getAvatarHandler = async () => {
@@ -39,6 +41,44 @@ export default function UserInfo(props: {
     getAvatarHandler();
   }, [profileImgIsUp]);
 
+  useEffect(() => {
+    const node = document.getElementById(props.username + "info");
+    node?.addEventListener("mouseenter", () => {
+      setIsMouseEnter(true);
+    });
+    node?.addEventListener("mouseleave", () => {
+      setIsMouseEnter(false);
+    });
+
+    return () => {
+      node?.removeEventListener("mouseenter", () => {
+        setIsMouseEnter(true);
+      });
+      node?.removeEventListener("mouseleave", () => {
+        setIsMouseEnter(false);
+      });
+    };
+  });
+  // const socket = getSocket();
+
+  // TODO: dm exit 완성 필요
+  // useEffect(() => {
+  //   socket.on("dmExitResult", (res) => {
+  //     console.log(res);
+  //   });
+  //   return () => {
+  //     socket.off("dmExitResult", (res) => {
+  //       console.log(res);
+  //     });
+  //   };
+  // });
+
+  function onDmExit() {
+    alert("dm 나가기!");
+    // TODO: dm exit 서버 구현되면 완성하기!
+    // socket.emit("dmExit", { username: props.username });
+  }
+
   function onDmOpen() {
     if (props.listOf === "dm") setDmIsOpen(true);
   }
@@ -48,7 +88,7 @@ export default function UserInfo(props: {
   }
 
   return (
-    <>
+    <S.UserItem key={props.username} id={props.username + "info"} clickable={props.listOf === "dm"}>
       {dmIsOpen && <DmModal targetUser={props.username} onClose={onDmClose} />}
       <S.TmpImg src={img} clickable={props.listOf === "dm"} onClick={onDmOpen} />
       <S.UserInfoText clickable={props.listOf === "dm"} onClick={onDmOpen}>
@@ -58,6 +98,7 @@ export default function UserInfo(props: {
         <br />
         {props.subLine}
       </S.UserInfoText>
+      {props.listOf === "dm" && isMouseEnter && <S.ExitDmIcon onClick={onDmExit} />}
       {props.listOf !== "dm" && !me && <S.KebabIcon onClick={onDropOpen} />}
       {dropIsOpen && (
         <UserDropMenu
@@ -69,6 +110,6 @@ export default function UserInfo(props: {
           banned={props.banned}
         />
       )}
-    </>
+    </S.UserItem>
   );
 }

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useState } from "react";
-import { ProfileContext, ProfileImgIsUpContext } from "hooks/context/ProfileContext";
+import { ProfileImgIsUpContext } from "hooks/context/ProfileContext";
 import UserDropMenu from "./UserDropMenu";
-import useNotiModal from "hooks/useNotiModal";
 import useDropModal from "hooks/useDropModal";
 import { getUsername } from "userAuth";
 import { getAvatar } from "api/user";
@@ -14,8 +13,8 @@ export default function UserInfo(props: {
   subLine: string;
   muted?: boolean;
   banned?: boolean;
+  onClickProfile?: () => void;
 }) {
-  const setProfileUser = useContext(ProfileContext);
   const profileImgIsUp = useContext(ProfileImgIsUpContext);
   const me = getUsername() === props.username;
   const { onDropOpen, onDropClose, dropIsOpen } = useDropModal({
@@ -23,7 +22,6 @@ export default function UserInfo(props: {
     username: props.username,
   });
   const [img, setImg] = useState("");
-  const { showNotiModal, NotiModal, onOpenNotiModal, newNoti } = useNotiModal();
 
   useEffect(() => {
     const getAvatarHandler = async () => {
@@ -41,18 +39,17 @@ export default function UserInfo(props: {
 
   return (
     <>
-      {showNotiModal && NotiModal}
       <S.TmpImg
         src={img}
-        me={props.listOf === undefined}
+        clickable={props.listOf === undefined}
         onClick={() => {
-          !props.listOf && setProfileUser && setProfileUser(props.username);
+          // TODO
         }}
       />
       <S.UserInfoText
-        me={!props.listOf}
+        clickable={!props.listOf}
         onClick={() => {
-          !props.listOf && setProfileUser && setProfileUser(props.username);
+          // TODO
         }}
       >
         {props.username}{" "}
@@ -61,13 +58,7 @@ export default function UserInfo(props: {
         <br />
         {props.subLine}
       </S.UserInfoText>
-      {props.listOf ? (
-        !me && <S.KebabIcon onClick={onDropOpen} />
-      ) : newNoti ? (
-        <S.NewNotiIcon onClick={onOpenNotiModal} />
-      ) : (
-        <S.EmptyNotiIcon onClick={onOpenNotiModal} />
-      )}
+      {props.listOf && !me && <S.KebabIcon onClick={onDropOpen} />}
       {dropIsOpen && (
         <UserDropMenu
           onClose={onDropClose}

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { ProfileImgIsUpContext } from "hooks/context/ProfileContext";
 import UserDropMenu from "./UserDropMenu";
 import useDropModal from "hooks/useDropModal";
@@ -73,7 +73,8 @@ export default function UserInfo(props: {
   //   };
   // });
 
-  function onDmExit() {
+  function onDmExit(e: React.MouseEvent<SVGElement>) {
+    e.stopPropagation();
     alert("dm 나가기!");
     // TODO: dm exit 서버 구현되면 완성하기!
     // socket.emit("dmExit", { username: props.username });

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -40,7 +40,7 @@ export default function UserInfo(props: {
   }, [profileImgIsUp]);
 
   function onDmOpen() {
-    setDmIsOpen(true);
+    if (props.listOf === "dm") setDmIsOpen(true);
   }
 
   function onDmClose() {
@@ -62,7 +62,7 @@ export default function UserInfo(props: {
       {dropIsOpen && (
         <UserDropMenu
           onClose={onDropClose}
-          onDmOpen={onDmOpen}
+          onDmOpen={() => setDmIsOpen(true)}
           targetUser={props.username}
           targetOper={props.userOper}
           targetMuted={props.muted}

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -85,6 +85,7 @@ export default function UserInfo({
         {username} {userOper === "owner" ? "👑" : userOper === "admin" ? "🎩" : ""}
         {muted ? " 🤐" : ""}
         <br />
+        {listOf === "dm" ? "✉️ " : ""}
         {subLine}
       </S.UserInfoText>
       {isMouseEnter && <S.ExitDmIcon onClick={onDmExit} />}

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -58,7 +58,7 @@ export default function UserInfo(props: {
         setIsMouseEnter(false);
       });
     };
-  });
+  }, []);
   // const socket = getSocket();
 
   // TODO: dm exit 완성 필요
@@ -88,10 +88,14 @@ export default function UserInfo(props: {
   }
 
   return (
-    <S.UserItem key={props.username} id={props.username + "info"} clickable={props.listOf === "dm"}>
-      {dmIsOpen && <DmModal targetUser={props.username} onClose={onDmClose} />}
-      <S.TmpImg src={img} clickable={props.listOf === "dm"} onClick={onDmOpen} />
-      <S.UserInfoText clickable={props.listOf === "dm"} onClick={onDmOpen}>
+    <S.UserItem
+      key={props.username}
+      id={props.username + "info"}
+      clickable={props.listOf === "dm"}
+      onClick={onDmOpen}
+    >
+      <S.TmpImg src={img} clickable={props.listOf === "dm"} />
+      <S.UserInfoText clickable={props.listOf === "dm"}>
         {props.username}{" "}
         {props.userOper === "owner" ? "👑" : props.userOper === "admin" ? "🎩" : ""}
         {props.muted ? " 🤐" : ""}
@@ -110,6 +114,7 @@ export default function UserInfo(props: {
           banned={props.banned}
         />
       )}
+      {dmIsOpen && <DmModal targetUser={props.username} onClose={onDmClose} />}
     </S.UserItem>
   );
 }

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -7,6 +7,7 @@ import { getAvatar } from "api/user";
 import DmModal from "modal/DmModal";
 // import { getSocket } from "socket/socket";
 import * as S from "./style";
+import { useModal } from "hooks/useModal";
 
 export default function UserInfo(props: {
   listOf?: string;
@@ -23,7 +24,7 @@ export default function UserInfo(props: {
     listOf: props.listOf,
     username: props.username,
   });
-  const [dmIsOpen, setDmIsOpen] = useState(false);
+  const { Modal, isOpen, onOpen, onClose } = useModal();
   const [img, setImg] = useState("");
   const [isMouseEnter, setIsMouseEnter] = useState(false);
 
@@ -81,11 +82,7 @@ export default function UserInfo(props: {
   }
 
   function onDmOpen() {
-    if (props.listOf === "dm") setDmIsOpen(true);
-  }
-
-  function onDmClose() {
-    setDmIsOpen(false);
+    if (props.listOf === "dm") onOpen();
   }
 
   return (
@@ -108,14 +105,18 @@ export default function UserInfo(props: {
       {dropIsOpen && (
         <UserDropMenu
           onClose={onDropClose}
-          onDmOpen={() => setDmIsOpen(true)}
+          onDmOpen={onOpen}
           targetUser={props.username}
           targetOper={props.userOper}
           targetMuted={props.muted}
           banned={props.banned}
         />
       )}
-      {dmIsOpen && <DmModal targetUser={props.username} onClose={onDmClose} />}
+      {isOpen && (
+        <Modal>
+          <DmModal targetUser={props.username} onClose={onClose} />
+        </Modal>
+      )}
     </S.UserItem>
   );
 }

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -5,6 +5,7 @@ import useDropModal from "hooks/useDropModal";
 import { getUsername } from "userAuth";
 import { getAvatar } from "api/user";
 import * as S from "./style";
+import DmModal from "modal/DmModal";
 
 export default function UserInfo(props: {
   listOf?: string;
@@ -21,6 +22,7 @@ export default function UserInfo(props: {
     listOf: props.listOf,
     username: props.username,
   });
+  const [dmIsOpen, setDmIsOpen] = useState(false);
   const [img, setImg] = useState("");
 
   useEffect(() => {
@@ -39,17 +41,18 @@ export default function UserInfo(props: {
 
   return (
     <>
+      {dmIsOpen && <DmModal targetUser={props.username} onClose={setDmIsOpen} />}
       <S.TmpImg
         src={img}
-        clickable={props.listOf === undefined}
+        clickable={props.listOf === "dm"}
         onClick={() => {
-          // TODO
+          setDmIsOpen(true);
         }}
       />
       <S.UserInfoText
-        clickable={!props.listOf}
+        clickable={props.listOf === "dm"}
         onClick={() => {
-          // TODO
+          setDmIsOpen(true);
         }}
       >
         {props.username}{" "}
@@ -58,7 +61,7 @@ export default function UserInfo(props: {
         <br />
         {props.subLine}
       </S.UserInfoText>
-      {props.listOf && !me && <S.KebabIcon onClick={onDropOpen} />}
+      {props.listOf !== "dm" && !me && <S.KebabIcon onClick={onDropOpen} />}
       {dropIsOpen && (
         <UserDropMenu
           onClose={onDropClose}

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -82,7 +82,10 @@ export default function UserInfo(props: {
   }
 
   function onDmOpen() {
-    if (props.listOf === "dm") onOpen();
+    if (props.listOf === "dm") {
+      setIsMouseEnter(false);
+      onOpen();
+    }
   }
 
   return (

--- a/src/components/rightSide/user/UserList.tsx
+++ b/src/components/rightSide/user/UserList.tsx
@@ -2,12 +2,14 @@ import { useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getProfile } from "api/user";
 import { BanListArray, UserListArray } from "socket/passive/chatRoomType";
+import { DmListArray } from "socket/passive/friendDmListType";
 import { ProfileImgIsUpContext } from "hooks/context/ProfileContext";
 import UserInfo from "./UserInfo";
 import * as S from "../style";
 
 type UserListCase =
-  | { listOf: "friend" | "dm" | "player" | "observer" }
+  | { listOf: "friend" | "player" | "observer" }
+  | { listOf: "dm"; list: DmListArray | null }
   | { listOf: "participant"; list: UserListArray | null }
   | { listOf: "banned"; list: BanListArray | null };
 
@@ -25,7 +27,6 @@ export default function UserList(props: UserListCase) {
   if (profileQuery.isLoading) return <S.UserListLayout></S.UserListLayout>;
   if (profileQuery.isError) console.log(profileQuery.error);
 
-  // TODO : user list 받아와서 전체 값 통일하기
   return (
     <S.UserListLayout>
       <h3>{props.listOf}</h3>
@@ -44,7 +45,6 @@ export default function UserList(props: UserListCase) {
               </S.UserItem>
             );
           })}
-        {/* TODO: 소켓 이벤트 데이터 연동 필요, key 값에 username */}
         {props.listOf === "banned" &&
           props.list?.map((user) => {
             return (
@@ -58,7 +58,15 @@ export default function UserList(props: UserListCase) {
               </S.UserItem>
             );
           })}
-        {!["participant", "banned"].includes(props.listOf) && (
+        {props.listOf === "dm" &&
+          props.list?.map((dm) => {
+            return (
+              <S.UserItem key={dm.username}>
+                <UserInfo listOf={props.listOf} username={dm.username} subLine="마지막 말" />
+              </S.UserItem>
+            );
+          })}
+        {!["participant", "banned", "dm"].includes(props.listOf) && (
           <S.UserItem>
             <UserInfo
               listOf={props.listOf}

--- a/src/components/rightSide/user/UserList.tsx
+++ b/src/components/rightSide/user/UserList.tsx
@@ -34,46 +34,45 @@ export default function UserList(props: UserListCase) {
         {props.listOf === "participant" &&
           props.list?.map((user) => {
             return (
-              <S.UserItem key={user.username}>
-                <UserInfo
-                  listOf={props.listOf}
-                  username={user.username}
-                  userOper={user.owner ? "owner" : user.admin ? "admin" : "participant"}
-                  subLine={user.login ? "🟣 온라인" : "⚫️ 오프라인"}
-                  muted={user.muted ? true : false}
-                />
-              </S.UserItem>
+              <UserInfo
+                key={user.username}
+                listOf={props.listOf}
+                username={user.username}
+                userOper={user.owner ? "owner" : user.admin ? "admin" : "participant"}
+                subLine={user.login ? "🟣 온라인" : "⚫️ 오프라인"}
+                muted={user.muted ? true : false}
+              />
             );
           })}
         {props.listOf === "banned" &&
           props.list?.map((user) => {
             return (
-              <S.UserItem key={user.username}>
-                <UserInfo
-                  listOf={props.listOf}
-                  username={user.username}
-                  subLine="❌ 입장금지"
-                  banned
-                />
-              </S.UserItem>
+              <UserInfo
+                key={user.username}
+                listOf={props.listOf}
+                username={user.username}
+                subLine="❌ 입장금지"
+                banned
+              />
             );
           })}
         {props.listOf === "dm" &&
           props.list?.map((dm) => {
             return (
-              <S.UserItem key={dm.username}>
-                <UserInfo listOf={props.listOf} username={dm.username} subLine="마지막 말" />
-              </S.UserItem>
+              <UserInfo
+                key={dm.username}
+                listOf={props.listOf}
+                username={dm.username}
+                subLine={dm.content}
+              />
             );
           })}
         {!["participant", "banned", "dm"].includes(props.listOf) && (
-          <S.UserItem>
-            <UserInfo
-              listOf={props.listOf}
-              username={profileQuery.data?.username}
-              subLine={profileQuery.data?.status === "login" ? "🟣 온라인" : "⚫️ 오프라인"}
-            />
-          </S.UserItem>
+          <UserInfo
+            listOf={props.listOf}
+            username={profileQuery.data?.username}
+            subLine={profileQuery.data?.status === "login" ? "🟣 온라인" : "⚫️ 오프라인"}
+          />
         )}
       </S.UserList>
     </S.UserListLayout>

--- a/src/components/rightSide/user/style.tsx
+++ b/src/components/rightSide/user/style.tsx
@@ -38,6 +38,10 @@ export const ProfileImg = styled.img<{ clickable: boolean }>`
 `;
 
 export const UserInfoText = styled.span<{ clickable: boolean }>`
+  max-width: 70%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   cursor: ${(props) => {
     if (props.clickable) return `pointer;`;
     return `default;`;

--- a/src/components/rightSide/user/style.tsx
+++ b/src/components/rightSide/user/style.tsx
@@ -20,7 +20,7 @@ export const UserItem = styled.li<{ clickable?: boolean }>`
   }}
 `;
 
-export const TmpImg = styled.img<{ clickable?: boolean }>`
+export const LoadingImg = styled.img<{ clickable?: boolean }>`
   width: 50px;
   height: 50px;
   border-radius: 100%;

--- a/src/components/rightSide/user/style.tsx
+++ b/src/components/rightSide/user/style.tsx
@@ -1,11 +1,24 @@
 import styled from "@emotion/styled";
 import { MdOutlineMoreVert } from "react-icons/md";
 import { VscBell, VscBellDot } from "react-icons/vsc";
+import { GrTrash } from "react-icons/gr";
 import { darkGray, darkMain, lightGray, lightMain } from "style/color";
+import { lightRed } from "style/color";
 
 /*
  *          User Info
  */
+
+export const UserItem = styled.li<{ clickable?: boolean }>`
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  list-style-type: none;
+
+  ${(props) => {
+    if (props.clickable) return `cursor: pointer;`;
+  }}
+`;
 
 export const TmpImg = styled.img<{ clickable: boolean }>`
   width: 50px;
@@ -24,15 +37,26 @@ export const UserInfoText = styled.span<{ clickable: boolean }>`
   }};
 `;
 
-export const KebabIcon = styled(MdOutlineMoreVert)`
+/*
+ *          Dm: Trash Can
+ */
+
+export const ExitDmIcon = styled(GrTrash)`
   width: 20px;
   height: 100%;
+  padding: 2px;
   margin-left: auto;
   cursor: pointer;
+  /* TODO: 컬러 변경 적용 */
+  color: ${lightRed};
 `;
 
+/*
+ *          MyProfile: Notification
+ */
+
 export const EmptyNotiIcon = styled(VscBell)`
-  width: 16px;
+  width: 20px;
   padding: 2px;
   height: 100%;
   margin-left: auto;
@@ -40,7 +64,7 @@ export const EmptyNotiIcon = styled(VscBell)`
 `;
 
 export const NewNotiIcon = styled(VscBellDot)`
-  width: 16px;
+  width: 20px;
   padding: 2px;
   height: 100%;
   margin-left: auto;
@@ -49,8 +73,15 @@ export const NewNotiIcon = styled(VscBellDot)`
 `;
 
 /*
- *          Drop Menu
+ *          Basic: Drop Menu
  */
+
+export const KebabIcon = styled(MdOutlineMoreVert)`
+  width: 20px;
+  height: 100%;
+  margin-left: auto;
+  cursor: pointer;
+`;
 
 export const DropModalOverlay = styled.div`
   position: fixed;

--- a/src/components/rightSide/user/style.tsx
+++ b/src/components/rightSide/user/style.tsx
@@ -47,8 +47,9 @@ export const ExitDmIcon = styled(GrTrash)`
   padding: 2px;
   margin-left: auto;
   cursor: pointer;
-  /* TODO: 컬러 변경 적용 */
-  color: ${lightRed};
+  path {
+    stroke: ${lightRed};
+  }
 `;
 
 /*

--- a/src/components/rightSide/user/style.tsx
+++ b/src/components/rightSide/user/style.tsx
@@ -7,19 +7,19 @@ import { darkGray, darkMain, lightGray, lightMain } from "style/color";
  *          User Info
  */
 
-export const TmpImg = styled.img<{ me: boolean }>`
+export const TmpImg = styled.img<{ clickable: boolean }>`
   width: 50px;
   height: 50px;
   border-radius: 100%;
 
   ${(props) => {
-    if (props.me) return `cursor: pointer;`;
+    if (props.clickable) return `cursor: pointer;`;
   }}
 `;
 
-export const UserInfoText = styled.span<{ me: boolean }>`
+export const UserInfoText = styled.span<{ clickable: boolean }>`
   cursor: ${(props) => {
-    if (props.me) return `pointer;`;
+    if (props.clickable) return `pointer;`;
     return `default;`;
   }};
 `;

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -13,7 +13,8 @@ export default function useModal() {
     setIsOpen(true);
   }
 
-  function onClose() {
+  function onClose(e: MouseEvent) {
+    e.stopPropagation();
     setIsOpen(false);
   }
 

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -5,7 +5,7 @@ type ModalProps = {
   children: React.ReactNode;
 };
 
-export function useModal() {
+export default function useModal() {
   const [isOpen, setIsOpen] = useState(false);
 
   function onOpen() {

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { ModalOverlay } from "modal/layout/style";
+import ModalContainer from "modal/layout/ModalContainer";
 
 type ModalProps = {
   children: React.ReactNode;
@@ -18,10 +19,10 @@ export default function useModal() {
 
   function Modal({ children }: ModalProps) {
     return (
-      <>
+      <ModalContainer>
         <ModalOverlay />
         {children}
-      </>
+      </ModalContainer>
     );
   }
 

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import { ModalOverlay } from "modal/layout/style";
+
+type ModalProps = {
+  children: React.ReactNode;
+};
+
+export function useModal() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  function onOpen() {
+    setIsOpen(true);
+  }
+
+  function onClose() {
+    setIsOpen(false);
+  }
+
+  function Modal({ children }: ModalProps) {
+    return (
+      <>
+        <ModalOverlay />
+        {children}
+      </>
+    );
+  }
+
+  return {
+    Modal,
+    isOpen,
+    onOpen,
+    onClose,
+  };
+}

--- a/src/hooks/useMouseOver.tsx
+++ b/src/hooks/useMouseOver.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from "react";
 
 type MouseOverProps = {
   listOf: string | undefined;
-  node: HTMLElement | null;
+  user: string;
 };
 
-export default function useMouseOver({ listOf, node }: MouseOverProps) {
+export default function useMouseOver({ listOf, user }: MouseOverProps) {
   if (listOf !== "dm") return { isMouseEnter: false, onLeave: null };
 
   const [isMouseEnter, setIsMouseEnter] = useState(false);
@@ -19,6 +19,7 @@ export default function useMouseOver({ listOf, node }: MouseOverProps) {
   }
 
   useEffect(() => {
+    const node = document.getElementById(user + "info");
     node?.addEventListener("mouseenter", onEnter);
     node?.addEventListener("mouseleave", onLeave);
 
@@ -26,7 +27,7 @@ export default function useMouseOver({ listOf, node }: MouseOverProps) {
       node?.removeEventListener("mouseenter", onEnter);
       node?.removeEventListener("mouseleave", onLeave);
     };
-  }, [node]);
+  }, []);
 
   return { isMouseEnter, onLeave };
 }

--- a/src/hooks/useMouseOver.tsx
+++ b/src/hooks/useMouseOver.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+type MouseOverProps = {
+  listOf: string | undefined;
+  node: HTMLElement | null;
+};
+
+export default function useMouseOver({ listOf, node }: MouseOverProps) {
+  if (listOf !== "dm") return { isMouseEnter: false, onLeave: null };
+
+  const [isMouseEnter, setIsMouseEnter] = useState(false);
+
+  function onEnter() {
+    setIsMouseEnter(true);
+  }
+
+  function onLeave() {
+    setIsMouseEnter(false);
+  }
+
+  useEffect(() => {
+    node?.addEventListener("mouseenter", onEnter);
+    node?.addEventListener("mouseleave", onLeave);
+
+    return () => {
+      node?.removeEventListener("mouseenter", onEnter);
+      node?.removeEventListener("mouseleave", onLeave);
+    };
+  }, [node]);
+
+  return { isMouseEnter, onLeave };
+}

--- a/src/hooks/useOper.ts
+++ b/src/hooks/useOper.ts
@@ -18,7 +18,6 @@ export function useOper(operator: string, roomId: number, targetUser: string, on
     // TEST : 이벤트 결과 확인용
     if (res.status === "approved") {
       if (res.roomId === roomId) {
-        console.log("승인", res);
         onClose();
       }
     } else console.log("오류", res);

--- a/src/hooks/useOutsideClick.tsx
+++ b/src/hooks/useOutsideClick.tsx
@@ -2,12 +2,12 @@ import { useEffect } from "react";
 
 type OutSideClickProps = {
   modalRef: React.RefObject<HTMLDivElement>;
-  onClose: () => void;
+  onClose: (e: MouseEvent) => void;
 };
 
 export function useOutsideClick({ modalRef, onClose }: OutSideClickProps) {
   function handleClose(e: MouseEvent) {
-    if (modalRef.current && !modalRef.current.contains(e.target as Element)) onClose();
+    if (modalRef.current && !modalRef.current.contains(e.target as Element)) onClose(e);
   }
 
   useEffect(() => {

--- a/src/hooks/useOutsideClick.tsx
+++ b/src/hooks/useOutsideClick.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+type OutSideClickProps = {
+  modalRef: React.RefObject<HTMLDivElement>;
+  onClose: () => void;
+};
+
+export function useOutsideClick({ modalRef, onClose }: OutSideClickProps) {
+  function handleClose(e: MouseEvent) {
+    if (modalRef.current && !modalRef.current.contains(e.target as Element)) onClose();
+  }
+
+  useEffect(() => {
+    window.addEventListener("mousedown", handleClose);
+    return () => {
+      window.removeEventListener("mousedown", handleClose);
+    };
+  }, []);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -14,9 +14,19 @@ body {
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  box-sizing: border-box;
 }
 
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
+}
+
+* {
+  /* 오페라 */
+  box-sizing: border-box;
+  /* 파이어폭스 */
+  -moz-box-sizing: border-box;
+  /* 웹킷 & 크롬 */
+  -webkit-box-sizing: border-box;
+  /* iOS 사파리 기본 스타일 제거 */
+  /* -webkit-appearance: none; */
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,8 @@ import App from "./App";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-   <StrictMode>
-    <App />
-   </StrictMode>,
+  // TEST
+  //  <StrictMode>
+  <App />,
+  //  </StrictMode>,
 );

--- a/src/modal/DmModal.tsx
+++ b/src/modal/DmModal.tsx
@@ -1,19 +1,16 @@
-import { SetStateAction, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getSocket } from "socket/socket";
 import * as S from "modal/layout/style";
 import * as T from "socket/passive/friendDmListType";
 
-export default function DmModal(props: {
-  targetUser: string;
-  onClose: React.Dispatch<SetStateAction<boolean>>;
-}) {
+export default function DmModal(props: { targetUser: string; onClose: () => void }) {
   const socket = getSocket();
   const [dmChat, setDmChat] = useState<T.DmData[]>([]);
   const modalRef: React.RefObject<HTMLDivElement> = useRef(null);
   let key = 0;
 
   function handleClose(e: MouseEvent) {
-    if (modalRef.current && !modalRef.current.contains(e.target as Element)) props.onClose(false);
+    if (modalRef.current && !modalRef.current.contains(e.target as Element)) props.onClose();
   }
 
   useEffect(() => {
@@ -57,6 +54,12 @@ export default function DmModal(props: {
     <>
       <S.DmModalOverlay />
       <S.DmLayout ref={modalRef}>
+        <S.DmHeader>
+          <S.DmTitle>{props.targetUser}님과의 다이렉트 메시지</S.DmTitle>
+          <S.IconWrapper type="reset" onClick={props.onClose}>
+            <S.CloseIcon />
+          </S.IconWrapper>
+        </S.DmHeader>
         <S.DmChatBox>
           {dmChat.map((chat) => {
             return (
@@ -66,7 +69,19 @@ export default function DmModal(props: {
             );
           })}
         </S.DmChatBox>
-        {/* TODO: 입력창 만들기 / DM 전송 */}
+        <S.InputBox>
+          <S.DmInput />
+          <S.IconWrapper
+            type="submit"
+            onClick={(e) => {
+              // TODO: DM 전송 구현
+              e.preventDefault();
+              alert("DM 전송!");
+            }}
+          >
+            <S.SendBtn />
+          </S.IconWrapper>
+        </S.InputBox>
       </S.DmLayout>
     </>
   );

--- a/src/modal/DmModal.tsx
+++ b/src/modal/DmModal.tsx
@@ -7,7 +7,7 @@ import * as T from "socket/passive/friendDmListType";
 
 type DmModalProps = {
   targetUser: string;
-  onClose: () => void;
+  onClose: (e: MouseEvent) => void;
 };
 
 export default function DmModal({ targetUser, onClose }: DmModalProps) {
@@ -86,7 +86,7 @@ export default function DmModal({ targetUser, onClose }: DmModalProps) {
     <S.DmLayout ref={modalRef}>
       <S.DmHeader>
         <S.DmTitle>{targetUser}님과의 다이렉트 메시지</S.DmTitle>
-        <S.IconWrapper type="reset" onClick={onClose}>
+        <S.IconWrapper onClick={onClose as unknown as React.MouseEventHandler<Element>}>
           <S.CloseIcon />
         </S.IconWrapper>
       </S.DmHeader>
@@ -107,7 +107,7 @@ export default function DmModal({ targetUser, onClose }: DmModalProps) {
       </S.DmChatList>
       <S.InputBox onSubmit={onSend}>
         <S.DmInput disabled={isLoading} id="input" value={input} onChange={handler} />
-        <S.IconWrapper type="submit">
+        <S.IconWrapper>
           <S.SendBtn />
         </S.IconWrapper>
       </S.InputBox>

--- a/src/modal/DmModal.tsx
+++ b/src/modal/DmModal.tsx
@@ -1,0 +1,73 @@
+import { SetStateAction, useEffect, useRef, useState } from "react";
+import { getSocket } from "socket/socket";
+import * as S from "modal/layout/style";
+import * as T from "socket/passive/friendDmListType";
+
+export default function DmModal(props: {
+  targetUser: string;
+  onClose: React.Dispatch<SetStateAction<boolean>>;
+}) {
+  const socket = getSocket();
+  const [dmChat, setDmChat] = useState<T.DmData[]>([]);
+  const modalRef: React.RefObject<HTMLDivElement> = useRef(null);
+  let key = 0;
+
+  function handleClose(e: MouseEvent) {
+    if (modalRef.current && !modalRef.current.contains(e.target as Element)) props.onClose(false);
+  }
+
+  useEffect(() => {
+    window.addEventListener("mousedown", handleClose);
+    return () => {
+      window.removeEventListener("mousedown", handleClose);
+    };
+  });
+
+  function listener(res: T.DmHistoryData | T.DmResult) {
+    if (res.type === "history" && dmChat.length === 0) {
+      res.list.map((chat) => {
+        setDmChat((prevChat) => [...prevChat, chat]);
+      });
+    } else if (res.type === "dm") {
+      setDmChat((prevChat) => [...prevChat, { from: res.from, content: res.content }]);
+    }
+  }
+
+  useEffect(() => {
+    socket.on("message", listener);
+    return () => {
+      socket.off("message", listener);
+    };
+  });
+
+  useEffect(() => {
+    socket.emit("subscribe", {
+      type: "dm",
+      username: props.targetUser,
+    });
+    return () => {
+      socket.emit("unsubscribe", {
+        type: "dm",
+        username: props.targetUser,
+      });
+    };
+  }, []);
+
+  return (
+    <>
+      <S.DmModalOverlay />
+      <S.DmLayout ref={modalRef}>
+        <S.DmChatBox>
+          {dmChat.map((chat) => {
+            return (
+              <li key={key++}>
+                {chat.from} : {chat.content}
+              </li>
+            );
+          })}
+        </S.DmChatBox>
+        {/* TODO: 입력창 만들기 / DM 전송 */}
+      </S.DmLayout>
+    </>
+  );
+}

--- a/src/modal/DmModal.tsx
+++ b/src/modal/DmModal.tsx
@@ -79,31 +79,28 @@ export default function DmModal(props: { targetUser: string; onClose: () => void
   }, []);
 
   return (
-    <>
-      <S.DmModalOverlay />
-      <S.DmLayout ref={modalRef}>
-        <S.DmHeader>
-          <S.DmTitle>{props.targetUser}님과의 다이렉트 메시지</S.DmTitle>
-          <S.IconWrapper type="reset" onClick={props.onClose}>
-            <S.CloseIcon />
-          </S.IconWrapper>
-        </S.DmHeader>
-        <S.DmChatList ref={listRef}>
-          {dmChat.map((chat) => {
-            return (
-              <li id={String(key)} key={key++}>
-                {chat.from} : {chat.content}
-              </li>
-            );
-          })}
-        </S.DmChatList>
-        <S.InputBox onSubmit={onSend}>
-          <S.DmInput id="input" value={input} onChange={handler} />
-          <S.IconWrapper type="submit">
-            <S.SendBtn />
-          </S.IconWrapper>
-        </S.InputBox>
-      </S.DmLayout>
-    </>
+    <S.DmLayout ref={modalRef}>
+      <S.DmHeader>
+        <S.DmTitle>{props.targetUser}님과의 다이렉트 메시지</S.DmTitle>
+        <S.IconWrapper type="reset" onClick={props.onClose}>
+          <S.CloseIcon />
+        </S.IconWrapper>
+      </S.DmHeader>
+      <S.DmChatList ref={listRef}>
+        {dmChat.map((chat) => {
+          return (
+            <li id={String(key)} key={key++}>
+              {chat.from} : {chat.content}
+            </li>
+          );
+        })}
+      </S.DmChatList>
+      <S.InputBox onSubmit={onSend}>
+        <S.DmInput id="input" value={input} onChange={handler} />
+        <S.IconWrapper type="submit">
+          <S.SendBtn />
+        </S.IconWrapper>
+      </S.InputBox>
+    </S.DmLayout>
   );
 }

--- a/src/modal/DmModal.tsx
+++ b/src/modal/DmModal.tsx
@@ -41,6 +41,7 @@ export default function DmModal({ targetUser, onClose }: DmModalProps) {
       username: targetUser,
       content: input,
     });
+    reset();
   }
 
   useEffect(() => {
@@ -60,10 +61,8 @@ export default function DmModal({ targetUser, onClose }: DmModalProps) {
     });
     socket.on("dmResult", (res) => {
       console.log("dm 전송 결과", res);
-      if (res.status === "approved") {
-        reset();
-      } else console.log("DM 오류", res);
       // TEST: DM 전송에서 발생할 에러 핸들링
+      if (res.status !== "approved") console.log("DM 오류", res);
     });
 
     return () => {

--- a/src/modal/DmModal.tsx
+++ b/src/modal/DmModal.tsx
@@ -26,15 +26,15 @@ export default function DmModal(props: { targetUser: string; onClose: () => void
   function onSend(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (input.length === 0) return;
-    socket.emit("dm", {
-      username: props.targetUser,
-      content: input,
-    });
     socket.on("dmResult", (res) => {
       if (res.status === "approved") {
         reset();
       } else console.log("DM 오류", res);
       // TEST: DM 전송에서 발생할 에러 핸들링
+    });
+    socket.emit("dm", {
+      username: props.targetUser,
+      content: input,
     });
   }
 

--- a/src/modal/DmModal.tsx
+++ b/src/modal/DmModal.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { getSocket } from "socket/socket";
 import useInput from "hooks/useInput";
+import { useOutsideClick } from "hooks/useOutsideClick";
 import * as S from "modal/layout/style";
 import * as T from "socket/passive/friendDmListType";
-import { useOutsideClick } from "hooks/useOutsideClick";
 
 type DmModalProps = {
   targetUser: string;
@@ -92,10 +92,16 @@ export default function DmModal({ targetUser, onClose }: DmModalProps) {
       </S.DmHeader>
       <S.DmChatList ref={listRef}>
         {dmChat.map((chat) => {
+          if (chat.from === targetUser)
+            return (
+              <S.OpponentChat id={String(key)} key={key++}>
+                {chat.content}
+              </S.OpponentChat>
+            );
           return (
-            <li id={String(key)} key={key++}>
-              {chat.from} : {chat.content}
-            </li>
+            <S.MyChat id={String(key)} key={key++}>
+              {chat.content}
+            </S.MyChat>
           );
         })}
       </S.DmChatList>

--- a/src/modal/layout/ModalContainer.tsx
+++ b/src/modal/layout/ModalContainer.tsx
@@ -1,0 +1,10 @@
+import { createPortal } from "react-dom";
+
+type ChildrenProps = {
+  children: React.ReactNode;
+};
+
+export default function ModalContainer({ children }: ChildrenProps) {
+  const modalRoot = document.getElementById("modal-root");
+  return createPortal(<div>{children}</div>, modalRoot as Element);
+}

--- a/src/modal/layout/style.tsx
+++ b/src/modal/layout/style.tsx
@@ -16,6 +16,7 @@ export const ModalOverlay = styled.div`
   top: 0;
 
   background: rgba(0, 0, 0, 0.1);
+  cursor: default;
 `;
 
 export const Backdrop = styled.div`
@@ -30,7 +31,7 @@ export const Backdrop = styled.div`
 
 export const Modal = styled.dialog`
   width: 40%;
-  ${props => props.id  === "noti" ? "height: 200px;" : ""}
+  ${(props) => (props.id === "noti" ? "height: 200px;" : "")}
   border: none;
   border-radius: 12px;
   box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.08);
@@ -135,16 +136,6 @@ export const Wrapper = styled.div`
  *  DM modal
  */
 
-export const DmModalOverlay = styled.div`
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  right: 0;
-  top: 0;
-
-  background: rgba(0, 0, 0, 0.05);
-`;
-
 export const DmLayout = styled.div`
   position: absolute;
   top: 50%;
@@ -160,6 +151,7 @@ export const DmLayout = styled.div`
 
   display: flex;
   flex-direction: column;
+  cursor: default;
 `;
 
 export const DmHeader = styled.div`

--- a/src/modal/layout/style.tsx
+++ b/src/modal/layout/style.tsx
@@ -1,4 +1,8 @@
 import styled from "@emotion/styled";
+import * as font from "style/font";
+import { darkMain } from "style/color";
+import { AiOutlineCloseSquare } from "react-icons/ai";
+import { RiSendPlane2Line } from "react-icons/ri";
 
 /* 
   Common Modal style
@@ -139,16 +143,70 @@ export const DmLayout = styled.div`
   width: 400px;
   height: 600px;
   padding: 20px;
-  /* margin: 20px; */
 
   border: 1px solid;
   background-color: white;
+
+  display: flex;
+  flex-direction: column;
+`;
+
+export const DmHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 15px;
+`;
+
+export const DmTitle = styled.h1`
+  ${font.titleBold};
+  overflow: auto;
+  margin: 0;
+`;
+
+export const IconWrapper = styled.button`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  background: none;
+  border: none;
+  padding: 0;
+`;
+
+export const CloseIcon = styled(AiOutlineCloseSquare)`
+  width: 25px;
+  height: 25px;
 `;
 
 export const DmChatBox = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100%;
-
+  flex: 1 0 auto;
   overflow: auto;
+
+  ${font.body};
+  line-height: 1.7em;
+`;
+
+export const InputBox = styled.form`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+export const DmInput = styled.input`
+  width: 90%;
+  height: 35px;
+  border: 1px solid;
+  padding: 0px 5px;
+  outline-style: none;
+  ${font.body};
+`;
+
+export const SendBtn = styled(RiSendPlane2Line)`
+  width: 100%;
+  height: 30px;
+  color: ${darkMain};
 `;

--- a/src/modal/layout/style.tsx
+++ b/src/modal/layout/style.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import * as font from "style/font";
-import { darkMain } from "style/color";
+import { darkMain, lightMain } from "style/color";
 import { AiOutlineCloseSquare } from "react-icons/ai";
 import { RiSendPlane2Line } from "react-icons/ri";
 
@@ -187,14 +187,79 @@ export const DmChatList = styled.ul`
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
+  gap: 10px;
   overflow: auto;
 
   list-style: none;
   padding: 0;
-  margin: 0 5px 20px;
+  margin: 0 0px 20px;
 
   ${font.body};
   line-height: 1.7em;
+`;
+
+export const MyChat = styled.li`
+  max-width: calc(100% - 20px);
+  padding: 2px 5px;
+  border: 1px solid;
+  background-color: white;
+  position: relative;
+  margin-left: auto;
+  margin-right: 10px;
+
+  ::before {
+    border-top: 5px solid;
+    border-left: 5px solid;
+    border-right: 5px solid transparent;
+    border-bottom: 5px solid transparent;
+    content: "";
+    position: absolute;
+    right: -10px;
+    bottom: 7px;
+  }
+
+  ::after {
+    border-top: 4px solid white;
+    border-left: 4px solid white;
+    border-right: 4px solid transparent;
+    border-bottom: 4px solid transparent;
+    content: "";
+    position: absolute;
+    right: -8px;
+    bottom: 8px;
+  }
+`;
+
+export const OpponentChat = styled.li`
+  max-width: calc(100% - 20px);
+  padding: 2px 5px;
+  border: 1px solid;
+  background-color: ${lightMain};
+  position: relative;
+  margin-right: auto;
+  margin-left: 10px;
+
+  ::before {
+    border-top: 5px solid black;
+    border-left: 5px solid transparent;
+    border-right: 5px solid black;
+    border-bottom: 5px solid transparent;
+    content: "";
+    position: absolute;
+    left: -10px;
+    bottom: 7px;
+  }
+
+  ::after {
+    border-top: 4px solid ${lightMain};
+    border-left: 4px solid transparent;
+    border-right: 4px solid ${lightMain};
+    border-bottom: 4px solid transparent;
+    content: "";
+    position: absolute;
+    left: -8px;
+    bottom: 8px;
+  }
 `;
 
 export const InputBox = styled.form`

--- a/src/modal/layout/style.tsx
+++ b/src/modal/layout/style.tsx
@@ -180,12 +180,14 @@ export const CloseIcon = styled(AiOutlineCloseSquare)`
   height: 25px;
 `;
 
-export const DmChatBox = styled.div`
+export const DmChatBox = styled.ul`
   display: flex;
   flex-direction: column;
   flex: 1 0 auto;
   overflow: auto;
 
+  list-style: none;
+  padding: 0;
   ${font.body};
   line-height: 1.7em;
 `;

--- a/src/modal/layout/style.tsx
+++ b/src/modal/layout/style.tsx
@@ -180,14 +180,16 @@ export const CloseIcon = styled(AiOutlineCloseSquare)`
   height: 25px;
 `;
 
-export const DmChatBox = styled.ul`
+export const DmChatList = styled.ul`
   display: flex;
   flex-direction: column;
-  flex: 1 0 auto;
+  flex: 1 1 auto;
   overflow: auto;
 
   list-style: none;
   padding: 0;
+  margin: 0 5px 20px;
+
   ${font.body};
   line-height: 1.7em;
 `;

--- a/src/modal/layout/style.tsx
+++ b/src/modal/layout/style.tsx
@@ -115,3 +115,40 @@ export const Wrapper = styled.div`
   display: flex;
   justify-content: space-around;
 `;
+
+/*
+ *  DM modal
+ */
+
+export const DmModalOverlay = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  right: 0;
+  top: 0;
+
+  background: rgba(0, 0, 0, 0.05);
+`;
+
+export const DmLayout = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  width: 400px;
+  height: 600px;
+  padding: 20px;
+  /* margin: 20px; */
+
+  border: 1px solid;
+  background-color: white;
+`;
+
+export const DmChatBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  overflow: auto;
+`;

--- a/src/modal/layout/style.tsx
+++ b/src/modal/layout/style.tsx
@@ -8,6 +8,16 @@ import { RiSendPlane2Line } from "react-icons/ri";
   Common Modal style
 */
 
+export const ModalOverlay = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  right: 0;
+  top: 0;
+
+  background: rgba(0, 0, 0, 0.1);
+`;
+
 export const Backdrop = styled.div`
   position: fixed;
   top: 0;

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -25,7 +25,6 @@ const GameRoom = loadable(() => {
 
 function Auth() {
   const [profileUser, setProfileUser] = useState(getUsername());
-  const [profileImgIsUp, setProfileImgIsUp] = useState(false);
   const socket = getSocket();
 
   const errorListener = (res: { status: string; detail: string }) => {

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -32,12 +32,13 @@ function Auth() {
   const [profileImgIsUp, setProfileImgIsUp] = useState(false);
   const socket = getSocket();
 
+  // TEST: 구독/해제 테스트
   useEffect(() => {
-    socket.on("subscribeResult", (data) => console.log(data));
-    socket.on("unsubscribeResult", (data) => console.log(data));
+    socket.on("subscribeResult", (data) => console.log("구독", data));
+    socket.on("unsubscribeResult", (data) => console.log("구독해제", data));
     return () => {
-      socket.off("subscribeResult", (data) => console.log(data));
-      socket.off("unsubscribeResult", (data) => console.log(data));
+      socket.off("subscribeResult", (data) => console.log("구독", data));
+      socket.off("unsubscribeResult", (data) => console.log("구독해제", data));
     };
   }, []);
 

--- a/src/pages/auth/chat/list/JoinBtn.tsx
+++ b/src/pages/auth/chat/list/JoinBtn.tsx
@@ -22,7 +22,6 @@ export default function JoinChatRoom(props: PropsType) {
 
   const listner = (res: ChatRoomResponse) => {
     if (res.roomId !== props.roomId) return;
-    console.log("참가 결과", res);
     if (res.status === "error") {
       console.log(res);
     } else if (res.status === "warning") {

--- a/src/pages/auth/chat/list/style.tsx
+++ b/src/pages/auth/chat/list/style.tsx
@@ -3,9 +3,9 @@ import * as font from "style/font";
 import * as button from "style/button";
 
 export const PageLayout = styled.div`
-  width: 70%;
   height: 100%;
   padding: 5px 15px;
+  flex: 1 0 auto;
 `;
 
 export const HeaderBox = styled.div`

--- a/src/socket/passive/friendDmListType.ts
+++ b/src/socket/passive/friendDmListType.ts
@@ -4,6 +4,7 @@
 
 export type DmListArray = {
   username: string;
+  content: string;
 }[];
 
 export type DmList = {

--- a/src/socket/passive/friendDmListType.ts
+++ b/src/socket/passive/friendDmListType.ts
@@ -16,7 +16,7 @@ export interface DmData {
   content: string;
 }
 
-export interface DmResult extends DmData {
+export interface DmResponse extends DmData {
   type: "dm";
 }
 

--- a/src/socket/passive/friendDmListType.ts
+++ b/src/socket/passive/friendDmListType.ts
@@ -9,7 +9,7 @@ export type DmListArray = {
 
 export type DmList = {
   type: "dmList";
-  list: DmListArray;
+  alert: "new";
 };
 
 export interface DmData {

--- a/src/socket/passive/friendDmListType.ts
+++ b/src/socket/passive/friendDmListType.ts
@@ -1,3 +1,7 @@
+/*
+ *          DM
+ */
+
 export type DmListArray = {
   username: string;
 }[];
@@ -6,6 +10,24 @@ export type DmList = {
   type: "dmList";
   list: DmListArray;
 };
+
+export interface DmData {
+  from: string;
+  content: string;
+}
+
+export interface DmResult extends DmData {
+  type: "dm";
+}
+
+export type DmHistoryData = {
+  type: "history";
+  list: DmData[];
+};
+
+/*
+ *          Friend
+ */
 
 export type FriendListArray = {
   username: string;

--- a/src/socket/passive/friendDmListType.ts
+++ b/src/socket/passive/friendDmListType.ts
@@ -1,0 +1,18 @@
+export type DmListArray = {
+  username: string;
+}[];
+
+export type DmList = {
+  type: "dmList";
+  list: DmListArray;
+};
+
+export type FriendListArray = {
+  username: string;
+  status: string;
+}[];
+
+export type FriendList = {
+  type: "friend";
+  list: FriendListArray;
+};


### PR DESCRIPTION
## 개요
- dm 기능 구현

## 작업사항
- dm 리스트 구현 (REST api)
- dm 모달로 portal 사용하여 구현
- dm 전송 후 채팅 업데이트 구현
- dm 스타일 구현
- 새 dm 알림 아이콘 띄우는 로직 구현
- 모달 관련 기능 커스텀 훅으로 리팩토링
- dm 나가기 기능을 위한 아이콘 구현
- 이런저런 에러 픽스..

## 변경로직
- dm 리스트는 rest api로 변경

## 코멘트
- dm 나가기는 서버에서 기능 구현 끝나면 추가할 예정입니다!
- 잔에러 발생을 대비하여 여기저기 콘솔은 우선 삭제하지 않았고, 나가기까지 끝나면 삭제할게요!
- 다른 에러 수정하다 추가로 생긴 에러 : 유저 리스트가 길어져 스크롤바 생긴 경우 드롭다운 메뉴가 따라오지 않음 (해결이 어렵습니다..나중에...)
- dm 리스트가 열려있을 때 dm 보내다가 dm 모달 닫으면 dm 리스트 리페칭 시키기 (로직이 안 떠올라요..)

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
