### PR TITLE
fix: 로그아웃 시 쿼리 데이터 reset #84

### DIFF
--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom";
 import Modal from "modal/layout/Modal";
 import AvatarUploadModal from "modal/AvatarUploadModal";
 import { getAvatar } from "api/user";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 interface userProps {
   user?: {
@@ -37,6 +37,7 @@ export function ProfileData(props: userProps) {
   const navigate = useNavigate();
   const [showModal, setShowModal] = useState(false);
   const myProfile = getUsername() === props.user?.username;
+  const queryClient = useQueryClient();
 
   const avatarQuery = useQuery({
     queryKey: ["avatar", `${props.user?.username}`],
@@ -55,6 +56,16 @@ export function ProfileData(props: userProps) {
   const closeModalHandler = () => {
     setShowModal(false);
   };
+
+  function onLogout() {
+    distroyAuth();
+    disconnectSocket();
+    if (setSigned) setSigned(false);
+    queryClient.resetQueries(["profile"]);
+    queryClient.resetQueries(["avatar"]);
+    queryClient.resetQueries(["list"]);
+    navigate("/");
+  }
 
   return (
     <S.ProfileLayout>
@@ -113,19 +124,8 @@ export function ProfileData(props: userProps) {
           })}
       </S.HistoryList>
       <S.ButtonBox>
-        {(!user || user.relation === "myself") && (
-          <S.Button
-            onClick={() => {
-              distroyAuth();
-              disconnectSocket();
-              if (setSigned) setSigned(false);
-              navigate("/");
-            }}
-          >
-            로그아웃
-          </S.Button>
-        )}
-        {user && user.relation === "friend" && <S.Button>친구 삭제</S.Button>}
+        {(!user || user.relation === "myself") && <S.Button onClick={onLogout}>로그아웃</S.Button>}
+        {user && user?.relation === "friend" && <S.Button>친구 삭제</S.Button>}
         {user && user.relation === "others" && <S.Button>친구 추가</S.Button>}
       </S.ButtonBox>
     </S.ProfileLayout>


### PR DESCRIPTION
## 개요
- 캐싱된 데이터로 인해 유저프로필 에러 발생

## 작업사항
- 처음 생각한 수정 로직은 쿼리키에 로그인한 유저이름을 모두 작성하는 거였지만, 초기화될 때까지 일시적으로 캐싱 데이터가 늘어나는 것을 고려하여 로그아웃 시 쿼리 데이터를 reset하도록 수정

## 변경로직

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
