### PR TITLE
style: UI/UX 스타일 보완 #87

### DIFF
--- a/src/components/LoadingCircle.tsx
+++ b/src/components/LoadingCircle.tsx
@@ -1,0 +1,28 @@
+import styled from "@emotion/styled";
+
+export const LoadingCircle = styled.div<{ w: number; h: number }>`
+  display: inline-block;
+  ${(props) => {
+    return `width: ${props.w}px;
+    height: ${props.h}px;`;
+  }}
+  margin: auto;
+  border: 3px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  border-top-color: black;
+  animation: spin 1s ease-in-out infinite;
+  -webkit-animation: spin 1s ease-in-out infinite;
+
+  @keyframes spin {
+    to {
+      -webkit-transform: rotate(360deg);
+    }
+  }
+  @-webkit-keyframes spin {
+    to {
+      -webkit-transform: rotate(360deg);
+    }
+  }
+`;
+
+export default LoadingCircle;

--- a/src/components/header/style.tsx
+++ b/src/components/header/style.tsx
@@ -33,7 +33,7 @@ export const HeaderBtn = styled.button`
   border: none;
   ${(props: { clicked: boolean }) => {
     if (props.clicked)
-      return `border-bottom: 11px solid ${basicMain};
+      return `background: linear-gradient(to top, ${basicMain} 50%, transparent 50%);
     color: ${darkMain};`;
     return "";
   }}

--- a/src/components/leftSide/style.tsx
+++ b/src/components/leftSide/style.tsx
@@ -6,7 +6,7 @@ import * as button from "style/button";
 export const ProfileLayout = styled.div`
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 40px);
+  height: 100%;
 
   padding: 10px;
 `;
@@ -62,7 +62,8 @@ export const InfoValue = styled.span`
  */
 
 export const HistoryList = styled.ul`
-  height: 400px;
+  /* height: 400px; */
+  flex: 1 0 auto;
   overflow: auto;
 `;
 

--- a/src/components/rightSide/FriendAndDmBar.tsx
+++ b/src/components/rightSide/FriendAndDmBar.tsx
@@ -3,6 +3,7 @@ import UserList from "./user/UserList";
 import { getSocket } from "socket/socket";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getDmList } from "api/dm";
+import LoadingCircle from "components/LoadingCircle";
 import * as T from "socket/passive/friendDmListType";
 import * as S from "./style";
 
@@ -72,6 +73,7 @@ export default function FriendAndDmBar() {
           dmListQuery.isLoading ? (
             <S.UserListLayout>
               <h3>dm</h3>
+              <LoadingCircle w={50} h={50} />
             </S.UserListLayout>
           ) : (
             <UserList key={"dm"} listOf={isOpen} list={dmListQuery.data.list} />

--- a/src/modal/DmModal.tsx
+++ b/src/modal/DmModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { getSocket } from "socket/socket";
 import useInput from "hooks/useInput";
 import { useOutsideClick } from "hooks/useOutsideClick";
+import LoadingCircle from "components/LoadingCircle";
 import * as S from "modal/layout/style";
 import * as T from "socket/passive/friendDmListType";
 
@@ -91,19 +92,23 @@ export default function DmModal({ targetUser, onClose }: DmModalProps) {
         </S.IconWrapper>
       </S.DmHeader>
       <S.DmChatList ref={listRef}>
-        {dmChat.map((chat) => {
-          if (chat.from === targetUser)
+        {isLoading ? (
+          <LoadingCircle w={50} h={50} />
+        ) : (
+          dmChat.map((chat) => {
+            if (chat.from === targetUser)
+              return (
+                <S.OpponentChat id={String(key)} key={key++}>
+                  {chat.content}
+                </S.OpponentChat>
+              );
             return (
-              <S.OpponentChat id={String(key)} key={key++}>
+              <S.MyChat id={String(key)} key={key++}>
                 {chat.content}
-              </S.OpponentChat>
+              </S.MyChat>
             );
-          return (
-            <S.MyChat id={String(key)} key={key++}>
-              {chat.content}
-            </S.MyChat>
-          );
-        })}
+          })
+        )}
       </S.DmChatList>
       <S.InputBox onSubmit={onSend}>
         <S.DmInput disabled={isLoading} id="input" value={input} onChange={handler} />

--- a/src/modal/layout/style.tsx
+++ b/src/modal/layout/style.tsx
@@ -278,7 +278,7 @@ export const DmInput = styled.input`
 `;
 
 export const SendBtn = styled(RiSendPlane2Line)`
-  width: 100%;
+  width: 30px;
   height: 30px;
   color: ${darkMain};
 `;


### PR DESCRIPTION
## 개요
- UI/UX 스타일 보완

## 작업사항
크롬vs사파리: 크롬과 비교하여 기능상 방해가 되거나 UI를 해치는 부분 수정
- 상단 네비게이션 바
- DM 인풋 사이즈
- (UX 관점) 로딩이 긴 부분에 로딩중 표시

## 코멘트
- 크롬+사파리로 하기로 했던 것 같아서 두 브라우저만 보고 수정했습니다!
- dmList는 로딩이 좀 긴 편이라 로딩중이 필요할 것 같아 추가했는데, 채팅방은 호쏭님이 작업중인 부분인 것 같아 안 건드렸습니다!
- 혹시 채팅 히스토리 불러올 때 필요하시면 `Components/` 디렉토리에 있으니 import해서 사이즈 넣고 쓰시면 됩니다!

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
