### PR TITLE
feat: 채팅방 비번 설정 & 친구 취소

### DIFF
--- a/src/components/leftSide/AddFriendBtn.tsx
+++ b/src/components/leftSide/AddFriendBtn.tsx
@@ -31,5 +31,6 @@ export default function AddFriendBtn(props: { username: string }) {
       username: props.username,
     });
   };
+  
   return <S.Button onClick={addBtnHandler}>친구 추가</S.Button>;
 }

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -9,6 +9,7 @@ import Modal from "modal/layout/Modal";
 import AvatarUploadModal from "modal/AvatarUploadModal";
 import AddFriendBtn from "./AddFriendBtn";
 import * as S from "./style";
+import RemoveFrendBtn from "./RemoveFriendBtn";
 
 interface userProps {
   user?: {
@@ -128,7 +129,7 @@ export function ProfileData(props: userProps) {
       </S.HistoryList>
       <S.ButtonBox>
         {(!user || user.relation === "myself") && <S.Button onClick={onLogout}>로그아웃</S.Button>}
-        {user && user?.relation === "friend" && <S.Button>친구 삭제</S.Button>}
+        {user && user?.relation === "friend" && <RemoveFrendBtn username={user.username} />}
         {user && user.relation === "others" && <AddFriendBtn username={user.username} />}
       </S.ButtonBox>
     </S.ProfileLayout>

--- a/src/components/leftSide/RemoveFriendBtn.tsx
+++ b/src/components/leftSide/RemoveFriendBtn.tsx
@@ -1,0 +1,36 @@
+import { getSocket } from "socket/socket";
+import * as S from "./style";
+import { useQueryClient } from "@tanstack/react-query";
+import { ChatRoomResponse } from "socket/active/chatEventType";
+import { useEffect } from "react";
+
+export default function RemoveFrendBtn(props: { username: string }) {
+  const socket = getSocket();
+  const queryCli = useQueryClient();
+
+  const listener = (res: ChatRoomResponse) => {
+    if (res.status === "approved") {
+      alert("친구 취소 했습니다.");
+      queryCli.invalidateQueries(["profile", props.username]);
+    } else if (res.status === "warning") {
+      alert(res.detail);
+    } else {
+      console.log("removeFriendResult", res);
+    }
+  };
+
+  useEffect(() => {
+    socket.on("removeFriendResult", listener);
+    return () => {
+      socket.off("removeFriendResult", listener);
+    };
+  }, []);
+
+  const removeBtnHandler = () => {
+    socket.emit("removeFriend", {
+      username: props.username,
+    });
+  };
+
+  return <S.Button onClick={removeBtnHandler}>친구 취소</S.Button>;
+}

--- a/src/components/rightSide/user/FriendList.tsx
+++ b/src/components/rightSide/user/FriendList.tsx
@@ -1,5 +1,4 @@
 import UserInfo from "./UserInfo";
-import * as S from "../style";
 import { useEffect, useState } from "react";
 import { getSocket } from "socket/socket";
 

--- a/src/modal/SettingPwModal.tsx
+++ b/src/modal/SettingPwModal.tsx
@@ -1,0 +1,73 @@
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import * as S from "./layout/style";
+import { useParams, useSearchParams } from "react-router-dom";
+import { getSocket } from "socket/socket";
+
+type modalProps = {
+  close: () => void;
+  notice: string;
+  setNotice: Dispatch<SetStateAction<string>>;
+};
+
+export default function SettingPwModal(props: modalProps) {
+  const [pwInput, setPwInput] = useState("");
+  const [option, setOption] = useState("");
+  const [target, setTarget] = useSearchParams();
+  const { roomId } = useParams();
+  const [disable, setDisable] = useState(true);
+  const socket = getSocket();
+
+  function setStatusHandler(e: React.ChangeEvent<HTMLSelectElement>) {
+    setOption(e.target.value);
+    if (pwInput) setPwInput("");
+    if (props.notice) props.setNotice("");
+    if (e.target.value === "change" || e.target.value === "set") setDisable(false);
+    else setDisable(true);
+  }
+
+  function setPwHandler(e: React.ChangeEvent<HTMLInputElement>) {
+    setPwInput(e.target.value);
+  }
+
+  function setHandler(e: React.MouseEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    if (option === "change") {
+      socket.emit("changePassword", {
+        roomId: Number(roomId),
+        password: pwInput,
+      });
+    } else if (option === "set") {
+      socket.emit("setPassword", {
+        roomId: Number(roomId),
+        password: pwInput,
+      });
+    } else if (option === "remove") {
+      socket.emit("removePassword", {
+        roomId: Number(roomId),
+      });
+    }
+  }
+
+  return (
+    <S.SettingPwLayout>
+      <h2>{target.get("title")} 채팅방 비밀번호 설정</h2>
+      <form onSubmit={setHandler}>
+        <select onChange={setStatusHandler}>
+          <option value="opt">-- 옵션을 선택해주세요 --</option>
+          <option value="change">비밀번호 변경</option>
+          <option value="set">비밀번호 설정하기</option>
+          <option value="remove">비밀번호 설정취소</option>
+        </select>
+        <S.Wrapper>
+          <S.Input onChange={setPwHandler} value={pwInput} disabled={disable} />
+        </S.Wrapper>
+        <S.Span color="red">{props.notice}</S.Span>
+        <S.BtnWrapper>
+          <S.Button type="submit">확인</S.Button>
+          <S.Button type="button" onClick={props.close}>취소</S.Button>
+        </S.BtnWrapper>
+      </form>
+    </S.SettingPwLayout>
+  );
+}

--- a/src/modal/layout/style.tsx
+++ b/src/modal/layout/style.tsx
@@ -25,7 +25,7 @@ export const Backdrop = styled.div`
   left: 0;
   width: 100%;
   height: 100vh;
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: rgba(0, 0, 0, 0.4);
   z-index: 1;
 `;
 
@@ -282,3 +282,16 @@ export const SendBtn = styled(RiSendPlane2Line)`
   height: 30px;
   color: ${darkMain};
 `;
+
+/* 
+  setting pw chat room
+*/
+
+export const SettingPwLayout = styled.div`
+  position: relative;
+  width: 100%;
+  text-align: center;
+  background: white;
+  font-size: 12px;
+  border-radius: 20px;
+`

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -9,6 +9,7 @@ import NotFound from "pages/NotFound";
 import { ProfileContext } from "hooks/context/ProfileContext";
 import { getSocket } from "socket/socket";
 import * as S from "./style";
+import { useQueryClient } from "@tanstack/react-query";
 
 const ChatList = loadable(() => {
   return import("@page/chat/list/ChatList");
@@ -26,6 +27,7 @@ const GameRoom = loadable(() => {
 function Auth() {
   const [profileUser, setProfileUser] = useState(getUsername());
   const socket = getSocket();
+  const queryClient = useQueryClient();
 
   const errorListener = (res: { status: string; detail: string }) => {
     if (res.status === "error") {
@@ -38,6 +40,10 @@ function Auth() {
     console.log("구독", res.type);
     if (res.status === "error") {
       console.log("sub", res);
+    } else {
+      if (res.type === "chatInvitation") {
+        queryClient.invalidateQueries(["profile", getUsername()]);
+      }
     }
   }
 

--- a/src/pages/auth/chat/room/ChatRoom.tsx
+++ b/src/pages/auth/chat/room/ChatRoom.tsx
@@ -10,6 +10,7 @@ import { getSocket } from "socket/socket";
 import RightSide from "@rightSide/RightSide";
 import * as T from "socket/passive/chatRoomType";
 import * as S from "./style";
+import SettingBtn from "./SettingBtn";
 
 export default function ChatRoom() {
   const navigate = useNavigate();
@@ -59,10 +60,13 @@ export default function ChatRoom() {
     <>
       <S.PageLayout>
         <S.HeaderBox>
-          <S.H2>
-            {" "}
-            #{roomId} {target.get("title")} 채팅방 입장완료
-          </S.H2>
+          <S.TitleWrapper>
+            <S.H2>
+              {" "}
+              #{roomId} {target.get("title")} 채팅방 입장완료
+            </S.H2>
+            {myOper.current === "owner" && <SettingBtn />}
+          </S.TitleWrapper>
           <ExitBtn room={Number(roomId)} />
         </S.HeaderBox>
         <S.MainBox>

--- a/src/pages/auth/chat/room/SettingBtn.tsx
+++ b/src/pages/auth/chat/room/SettingBtn.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import * as S from "./style";
+import Modal from "modal/layout/Modal";
+import SettingPwModal from "modal/SettingPwModal";
+import { getSocket } from "socket/socket";
+import { useParams } from "react-router-dom";
+import { ChatRoomResponse } from "socket/active/chatEventType";
+
+export default function SettingBtn() {
+  const [showModal, setShowModal] = useState(false);
+  const [notice, setNotice] = useState("");
+  const socket = getSocket();
+  const { roomId } = useParams();
+
+  const listener = (res: ChatRoomResponse) => {
+    console.log(res);
+    if (res.roomId !== Number(roomId)) return;
+    if (res.status === "approved") {
+      alert("설정이 완료되었습니다.");
+      setShowModal(false);
+    } else {
+      setNotice(res.detail);
+    }
+  };
+
+  useEffect(() => {
+    socket.on("removePasswordResult", listener);
+    socket.on("changePasswordResult", listener);
+    socket.on("setPasswordResult", listener);
+    return () => {
+      socket.off("removePasswordResult", listener);
+      socket.off("changePasswordResult", listener);
+      socket.off("setPasswordResult", listener);
+    };
+  }, []);
+
+  const openModalHandler = () => {
+    setShowModal(true);
+  };
+
+  const closeModalHandler = () => {
+    setShowModal(false);
+  };
+
+  return (
+    <>
+      {showModal && (
+        <Modal setView={closeModalHandler}>
+          <SettingPwModal close={closeModalHandler} notice={notice} setNotice={setNotice} />
+        </Modal>
+      )}
+      <S.SettingBtnIcon size={30} onClick={openModalHandler} />
+    </>
+  );
+}

--- a/src/pages/auth/chat/room/style.tsx
+++ b/src/pages/auth/chat/room/style.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import * as font from "style/font";
 import * as color from "style/color";
+import { AiOutlineSetting } from "react-icons/ai";
 
 export const PageLayout = styled.div`
   height: 100%;
@@ -69,3 +70,15 @@ export const Input = styled.input`
   transition: border-color 0.2s cubic-bezier(0.25, 0.1, 0.25, 1);
   margin-right: 5px;
 `;
+
+/* SettingBtn */
+
+export const TitleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const SettingBtnIcon = styled(AiOutlineSetting)`
+  padding: 5px 0;
+  cursor: pointer;
+`


### PR DESCRIPTION
## 개요
- 채팅방 비번 설정 & 친구 취소

## 작업사항
- 프로필 로그인 상태 불러오기 : subscribe 응답으로 최신화
- 친구 취소 기능 연동
- 채팅방 비번 설정 연동

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
