### PR TITLE
feat: 채팅 내 사용자 block/unblock 기능 구현 #90

### DIFF
--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -6,36 +6,50 @@ import { UserListContext } from "hooks/context/UserListContext";
 import InviteBtn from "./InviteBtn";
 import * as S from "./style";
 
-export default function UserDropMenu(props: {
+type DropMenuProps = {
   onClose: () => void;
   onDmOpen: () => void;
   targetUser: string;
   targetOper?: string;
   targetMuted?: boolean;
+  targetBlocked?: boolean;
   banned?: boolean;
   subLine?: string;
-}) {
+};
+
+export default function UserDropMenu({
+  onClose,
+  onDmOpen,
+  targetUser,
+  targetOper,
+  targetMuted,
+  targetBlocked,
+  banned,
+  subLine,
+}: DropMenuProps) {
   const setProfileUser = useContext(ProfileContext);
   const roomId = Number(useParams().roomId);
   const dropRef: React.RefObject<HTMLDivElement> = useRef(null);
   const myOper = useContext(UserListContext)?.myOper;
-  const onAppointAdmin = useOper("appointAdmin", roomId, props.targetUser, props.onClose);
-  const onDismissAdmin = useOper("dismissAdmin", roomId, props.targetUser, props.onClose);
-  const onMute = useOper("mute", roomId, props.targetUser, props.onClose);
-  const onKick = useOper("kick", roomId, props.targetUser, props.onClose);
-  const onBan = useOper("ban", roomId, props.targetUser, props.onClose);
-  const onUnban = useOper("unban", roomId, props.targetUser, props.onClose);
-  const isOnline = props.subLine?.split(" ")[1] === "온라인" ? true : false;
+  const onAppointAdmin = useOper("appointAdmin", roomId, targetUser, onClose);
+  const onDismissAdmin = useOper("dismissAdmin", roomId, targetUser, onClose);
+  const onMute = useOper("mute", roomId, targetUser, onClose);
+  const onKick = useOper("kick", roomId, targetUser, onClose);
+  const onBan = useOper("ban", roomId, targetUser, onClose);
+  const onUnban = useOper("unban", roomId, targetUser, onClose);
+  const onBlock = useOper("block", roomId, targetUser, onClose);
+  const onUnblock = useOper("unblock", roomId, targetUser, onClose);
+  const isOnline = subLine?.split(" ")[1] === "온라인" ? true : false;
 
   function handleDm() {
-    props.onDmOpen();
-    props.onClose();
+    onDmOpen();
+    onClose();
   }
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
       if (dropRef.current && e.target instanceof Element && !dropRef.current.contains(e.target))
-        props.onClose();
+        onClose();
     };
 
     window.addEventListener("mousedown", handleClick);
@@ -46,23 +60,29 @@ export default function UserDropMenu(props: {
 
   return (
     <>
+      {/* TODO: 노출 조건 분리 필요 */}
       <S.DropModalOverlay />
       <S.DropMenuLayout ref={dropRef}>
         <S.DropMenuItemBox
           onClick={() => {
-            setProfileUser && onProfile(props.targetUser, setProfileUser, props.onClose);
+            setProfileUser && onProfile(targetUser, setProfileUser, onClose);
           }}
         >
           프로필
         </S.DropMenuItemBox>
         <S.DropMenuItemBox onClick={handleDm}>DM 보내기</S.DropMenuItemBox>
         <S.DropMenuItemBox>게임 신청</S.DropMenuItemBox>
-        {props.banned && <S.DropMenuItemBox onClick={onUnban}>입장 금지 해제</S.DropMenuItemBox>}
-        {!props.banned &&
-          props.targetOper &&
-          (myOper === "owner" || (myOper === "admin" && props.targetOper === "participant")) && (
+        {!banned && targetOper && myOper && targetBlocked ? (
+          <S.DropMenuItemBox onClick={onUnblock}>차단해제</S.DropMenuItemBox>
+        ) : (
+          <S.DropMenuItemBox onClick={onBlock}>차단</S.DropMenuItemBox>
+        )}
+        {banned && <S.DropMenuItemBox onClick={onUnban}>입장 금지 해제</S.DropMenuItemBox>}
+        {!banned &&
+          targetOper &&
+          (myOper === "owner" || (myOper === "admin" && targetOper === "participant")) && (
             <>
-              {props.targetMuted ? (
+              {targetMuted ? (
                 <S.DropMenuItemBox disabled>음소거중</S.DropMenuItemBox>
               ) : (
                 <S.DropMenuItemBox onClick={onMute}>음소거</S.DropMenuItemBox>
@@ -71,20 +91,17 @@ export default function UserDropMenu(props: {
               <S.DropMenuItemBox onClick={onBan}>입장 금지</S.DropMenuItemBox>
             </>
           )}
-        {!props.banned &&
-          props.targetOper &&
+        {!banned &&
+          targetOper &&
           myOper === "owner" &&
-          (props.targetOper === "admin" ? (
+          (targetOper === "admin" ? (
             <S.DropMenuItemBox onClick={onDismissAdmin}>부방장 해제</S.DropMenuItemBox>
           ) : (
             <S.DropMenuItemBox onClick={onAppointAdmin}>부방장 지정</S.DropMenuItemBox>
           ))}
-        {isOnline &&
-          myOper && myOper !== "participant" &&
-          !props.targetOper &&
-          !props.banned && (
-            <InviteBtn roomId={roomId} username={props.targetUser} close={props.onClose} />
-          )}
+        {isOnline && myOper && myOper !== "participant" && !targetOper && !banned && (
+          <InviteBtn roomId={roomId} username={targetUser} close={onClose} />
+        )}
       </S.DropMenuLayout>
     </>
   );

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -16,6 +16,7 @@ type UserInfoProps = {
   subLine: string;
   muted?: boolean;
   banned?: boolean;
+  blocked?: boolean;
 };
 
 export default function UserInfo({
@@ -25,6 +26,7 @@ export default function UserInfo({
   subLine,
   muted,
   banned,
+  blocked,
 }: UserInfoProps) {
   const me = getUsername() === username;
   const { onDropOpen, onDropClose, dropIsOpen } = useDropModal({
@@ -83,7 +85,7 @@ export default function UserInfo({
       )}
       <S.UserInfoText clickable={listOf === "dm"}>
         {username} {userOper === "owner" ? "👑" : userOper === "admin" ? "🎩" : ""}
-        {muted ? " 🤐" : ""}
+        {muted ? " 🤐" : ""} {blocked ? " 🚫" : ""}
         <br />
         {listOf === "dm" ? "✉️ " : ""}
         {subLine}
@@ -97,6 +99,7 @@ export default function UserInfo({
           targetUser={username}
           targetOper={userOper}
           targetMuted={muted}
+          targetBlocked={blocked}
           banned={banned}
           subLine={subLine}
         />

--- a/src/components/rightSide/user/UserList.tsx
+++ b/src/components/rightSide/user/UserList.tsx
@@ -1,10 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
-import { getProfile } from "api/user";
+import { useContext } from "react";
 import { BanListArray, UserListArray } from "socket/passive/chatRoomType";
 import { DmListArray } from "socket/passive/friendDmListType";
 import UserInfo from "./UserInfo";
-import * as S from "../style";
 import FriendList from "./FriendList";
+import { UserListContext } from "hooks/context/UserListContext";
+import * as S from "../style";
 
 type UserListCase =
   | { listOf: "friend" | "player" | "observer" }
@@ -13,16 +13,7 @@ type UserListCase =
   | { listOf: "banned"; list: BanListArray | null };
 
 export default function UserList(props: UserListCase) {
-  // 임시 쿼리. 친구 리스트 불러오는 api 필요
-  const profileQuery = useQuery({
-    queryKey: ["profile", "아무개"],
-    queryFn: () => {
-      return getProfile("아무개");
-    },
-  });
-
-  if (profileQuery.isLoading) return <S.UserListLayout></S.UserListLayout>;
-  if (profileQuery.isError) console.log(profileQuery.error);
+  const blockList = useContext(UserListContext)?.blocked;
 
   return (
     <S.UserListLayout>
@@ -30,6 +21,12 @@ export default function UserList(props: UserListCase) {
       <S.UserList>
         {props.listOf === "participant" &&
           props.list?.map((user) => {
+            const blocked = blockList?.find((data) => {
+              return data.username === user.username;
+            })
+              ? true
+              : false;
+
             return (
               <UserInfo
                 key={user.username}
@@ -38,6 +35,7 @@ export default function UserList(props: UserListCase) {
                 userOper={user.owner ? "owner" : user.admin ? "admin" : "participant"}
                 subLine={user.status === "login" ? "🟣 온라인" : "⚫️ 오프라인"}
                 muted={user.muted ? true : false}
+                blocked={blocked}
               />
             );
           })}

--- a/src/hooks/context/UserListContext.ts
+++ b/src/hooks/context/UserListContext.ts
@@ -4,6 +4,7 @@ import { UserListArray, BanListArray } from "socket/passive/chatRoomType";
 export type UserListSet = {
   participant: UserListArray | null;
   banned: BanListArray | null;
+  blocked: BanListArray | null;
   myOper: string;
 };
 

--- a/src/hooks/useOper.ts
+++ b/src/hooks/useOper.ts
@@ -31,6 +31,8 @@ export function useOper(operator: string, roomId: number, targetUser: string, on
   }, []);
 
   return function onOper() {
+    // TEST: 블락/언블락 테스트
+    console.log("emit 전송", roomId, targetUser);
     socket.emit(operator, {
       roomId,
       username: targetUser,

--- a/src/pages/auth/chat/room/ChatRoom.tsx
+++ b/src/pages/auth/chat/room/ChatRoom.tsx
@@ -21,9 +21,12 @@ export default function ChatRoom() {
   const [target, setTarget] = useSearchParams();
   const [participant, setParticipant] = useState<T.UserListArray | null>(null);
   const [banned, setBanned] = useState<T.BanListArray | null>(null);
+  const [blocked, setBlocked] = useState<T.BanListArray | null>(null);
   const myOper = useRef("participant");
 
-  function handleChatRoom(res: T.ChatData | T.HistoryData | T.ChatRoomData | T.AffectedData) {
+  function handleChatRoom(
+    res: T.ChatData | T.HistoryData | T.ChatRoomData | T.AffectedData | T.BlockData,
+  ) {
     // TEST: 채팅방 내 전체 이벤트 리스너
     if (res.roomId !== Number(roomId) || res.type === "chat") return;
     console.log("채팅방", res);
@@ -38,6 +41,8 @@ export default function ChatRoom() {
       // TODO: 추방 알림 모달로?
       alert(res.from + "님이 " + getUsername() + "님을 내보냈습니다.");
       navigate("/chat/list");
+    } else if (res.type === "block") {
+      setBlocked(res.list);
     }
   }
 
@@ -70,7 +75,7 @@ export default function ChatRoom() {
           <SendBtn room={Number(roomId)} />
         </S.MainBox>
       </S.PageLayout>
-      <UserListContext.Provider value={{ participant, banned, myOper: myOper.current }}>
+      <UserListContext.Provider value={{ participant, banned, blocked, myOper: myOper.current }}>
         <RightSide />
       </UserListContext.Provider>
     </>

--- a/src/socket/passive/chatRoomType.ts
+++ b/src/socket/passive/chatRoomType.ts
@@ -43,3 +43,9 @@ export type AffectedData = {
   roomId: number;
   from: string;
 };
+
+export type BlockData = {
+  type: "block";
+  roomId: number;
+  list: BanListArray;
+};


### PR DESCRIPTION
## 개요
- 채팅내 사용자 block/unblock 기능 구현

## 작업사항
- block/unblock 소켓 이벤트 연동
- 드롭메뉴 UI 구현
- 차단 대상에 대해 이모지로 표시
- 로직 테스트 완료

## 변경로직
- [채팅방을 나가지 않고 있을 때] 차단한 순간부터 대상의 챗이 보이지 않고, 해제한 순간부터 다시 보임
- [차단하고 이탈했다 돌아오면] 차단 대상의 챗이 보이지 않음, 해제한 순간부터 이후의 챗은 보임
- [차단 대상이 퇴장했다 돌아오면] 차단 유지
- [내가 퇴장했다 돌아오면] 차단 리셋

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
