### PR TITLE
refact: UserInfo/UserDropMenu 리팩토링 #96

### DIFF
--- a/src/components/rightSide/FriendAndDmBar.tsx
+++ b/src/components/rightSide/FriendAndDmBar.tsx
@@ -32,8 +32,6 @@ export default function FriendAndDmBar() {
 
   function handleList(res: T.DmList) {
     if (res.type !== "dmList") return;
-    // TEST: 테스트중
-    console.log("dm 리스트", res, "현재 열림:", isOpen);
     const dmNode = document.getElementById("modal-root")?.firstChild;
     if (!dmNode) {
       isOpen === "dm" ? queryClient.invalidateQueries(["list", "dm"]) : setIsNewDm(true);

--- a/src/components/rightSide/rightSideType.ts
+++ b/src/components/rightSide/rightSideType.ts
@@ -1,0 +1,18 @@
+export type ModalLayoutProps = {
+  children: React.ReactNode;
+};
+
+export type TargetStatusType = {
+  oper?: string;
+  muted?: boolean;
+  blocked?: boolean;
+};
+
+export type DropMenuProps = {
+  onClose: () => void;
+  onDmOpen: () => void;
+  menuFor: string;
+  targetUser: string;
+  targetStatus?: TargetStatusType;
+  subline: string;
+};

--- a/src/components/rightSide/rightSideType.ts
+++ b/src/components/rightSide/rightSideType.ts
@@ -3,6 +3,7 @@ export type ModalLayoutProps = {
 };
 
 export type TargetStatusType = {
+  status?: string;
   oper?: string;
   muted?: boolean;
   blocked?: boolean;
@@ -14,5 +15,4 @@ export type DropMenuProps = {
   menuFor: string;
   targetUser: string;
   targetStatus?: TargetStatusType;
-  subline: string;
 };

--- a/src/components/rightSide/rightSideType.ts
+++ b/src/components/rightSide/rightSideType.ts
@@ -1,3 +1,10 @@
+export type UserInfoProps = {
+  listOf: string;
+  username: string;
+  subLine: string;
+  userStatus?: TargetStatusType;
+};
+
 export type ModalLayoutProps = {
   children: React.ReactNode;
 };

--- a/src/components/rightSide/user/FriendList.tsx
+++ b/src/components/rightSide/user/FriendList.tsx
@@ -44,6 +44,7 @@ export default function FriendList(props: { listOf: string }) {
             listOf={props.listOf}
             username={user.username}
             subLine={user.status === "login" ? "🟣 온라인" : "⚫️ 오프라인"}
+            userStatus={{ status: user.status }}
           />
         );
       })}

--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useContext, useState } from "react";
+import { useEffect, useRef, useContext, useState, forwardRef } from "react";
 import { useParams } from "react-router-dom";
 import { ProfileContext } from "hooks/context/ProfileContext";
 import { useOper, onProfile } from "hooks/useOper";
@@ -6,30 +6,55 @@ import { UserListContext } from "hooks/context/UserListContext";
 import InviteBtn from "./InviteBtn";
 import * as S from "./style";
 
+type ModalLayoutProps = {
+  children: React.ReactNode;
+};
+
+const ModalLayout = forwardRef(function ModalLayout(
+  props: ModalLayoutProps,
+  ref: React.ForwardedRef<HTMLDivElement>,
+) {
+  return (
+    <>
+      <S.DropModalOverlay />
+      <S.DropMenuLayout ref={ref}>{props.children}</S.DropMenuLayout>
+    </>
+  );
+});
+
+type TargetStatusType = {
+  oper?: string;
+  muted?: boolean;
+  blocked?: boolean;
+};
+
 type DropMenuProps = {
   onClose: () => void;
   onDmOpen: () => void;
+  menuFor: string;
   targetUser: string;
-  targetOper?: string;
-  targetMuted?: boolean;
-  targetBlocked?: boolean;
-  banned?: boolean;
-  subLine?: string;
+  targetStatus?: TargetStatusType;
+  subline: string;
 };
+
+// 전체 필요한것 : onClose / onDmOpen / setProfile / menuFor(friend/participant/banned/player/observer) / targetUser
+// friend : 기본[프로필/게임신청/DM 보내기] + 채팅초대 : targetUser, isOnline(게임신청/채팅초대 block)
+// participant : 기본 + [차단] + 권한[음소거/내보내기/입장금지] + 방장[부방장 지정] : userOper, targetStatus(oper, muted, blocked, isOnline)
+// banned : 기본 + [입장금지 해제]
+// player : 기본[프로필/DM 보내기] - 게임신청
+// observer : 기본[프로필/게임신청/DM 보내기]
 
 export default function UserDropMenu({
   onClose,
   onDmOpen,
+  menuFor,
   targetUser,
-  targetOper,
-  targetMuted,
-  targetBlocked,
-  banned,
-  subLine,
+  targetStatus,
+  subline,
 }: DropMenuProps) {
   const setProfileUser = useContext(ProfileContext);
   const roomId = Number(useParams().roomId);
-  const dropRef: React.RefObject<HTMLDivElement> = useRef(null);
+  const dropRef = useRef<HTMLDivElement>(null);
   const myOper = useContext(UserListContext)?.myOper;
   const onAppointAdmin = useOper("appointAdmin", roomId, targetUser, onClose);
   const onDismissAdmin = useOper("dismissAdmin", roomId, targetUser, onClose);
@@ -39,7 +64,68 @@ export default function UserDropMenu({
   const onUnban = useOper("unban", roomId, targetUser, onClose);
   const onBlock = useOper("block", roomId, targetUser, onClose);
   const onUnblock = useOper("unblock", roomId, targetUser, onClose);
-  const isOnline = subLine?.split(" ")[1] === "온라인" ? true : false;
+  const isOnline = subline?.split(" ")[1] === "온라인" ? true : false;
+
+  const DefaultMenu = () => {
+    return (
+      <>
+        <S.DropMenuItemBox
+          onClick={() => {
+            setProfileUser && onProfile(targetUser, setProfileUser, onClose);
+          }}
+        >
+          프로필
+        </S.DropMenuItemBox>
+        <S.DropMenuItemBox onClick={handleDm}>DM 보내기</S.DropMenuItemBox>
+      </>
+    );
+  };
+
+  const InviteGame = () => {
+    return isOnline ? <S.DropMenuItemBox>게임 신청</S.DropMenuItemBox> : <></>;
+  };
+
+  const InviteChat = () => {
+    return myOper !== "participant" && isOnline ? (
+      <InviteBtn roomId={roomId} username={targetUser} close={onClose} />
+    ) : (
+      <></>
+    );
+  };
+
+  const BlockInChat = () => {
+    return targetStatus?.blocked ? (
+      <S.DropMenuItemBox onClick={onUnblock}>차단해제</S.DropMenuItemBox>
+    ) : (
+      <S.DropMenuItemBox onClick={onBlock}>차단</S.DropMenuItemBox>
+    );
+  };
+
+  const ForAdminInChat = () => {
+    return (
+      <>
+        {targetStatus?.muted ? (
+          <S.DropMenuItemBox disabled>음소거중</S.DropMenuItemBox>
+        ) : (
+          <S.DropMenuItemBox onClick={onMute}>음소거</S.DropMenuItemBox>
+        )}
+        <S.DropMenuItemBox onClick={onKick}>내보내기</S.DropMenuItemBox>
+        <S.DropMenuItemBox onClick={onBan}>입장 금지</S.DropMenuItemBox>
+      </>
+    );
+  };
+
+  const ForOwnerInChat = () => {
+    return targetStatus?.oper === "admin" ? (
+      <S.DropMenuItemBox onClick={onDismissAdmin}>부방장 해제</S.DropMenuItemBox>
+    ) : (
+      <S.DropMenuItemBox onClick={onAppointAdmin}>부방장 지정</S.DropMenuItemBox>
+    );
+  };
+
+  const UnBan = () => {
+    return <S.DropMenuItemBox onClick={onUnban}>입장 금지 해제</S.DropMenuItemBox>;
+  };
 
   function handleDm() {
     onDmOpen();
@@ -48,6 +134,7 @@ export default function UserDropMenu({
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
+      console.log("클릭!", dropRef.current);
       if (dropRef.current && e.target instanceof Element && !dropRef.current.contains(e.target))
         onClose();
     };
@@ -58,51 +145,48 @@ export default function UserDropMenu({
     };
   }, [dropRef]);
 
-  return (
-    <>
-      {/* TODO: 노출 조건 분리 필요 */}
-      <S.DropModalOverlay />
-      <S.DropMenuLayout ref={dropRef}>
-        <S.DropMenuItemBox
-          onClick={() => {
-            setProfileUser && onProfile(targetUser, setProfileUser, onClose);
-          }}
-        >
-          프로필
-        </S.DropMenuItemBox>
-        <S.DropMenuItemBox onClick={handleDm}>DM 보내기</S.DropMenuItemBox>
-        <S.DropMenuItemBox>게임 신청</S.DropMenuItemBox>
-        {!banned && targetOper && myOper && targetBlocked ? (
-          <S.DropMenuItemBox onClick={onUnblock}>차단해제</S.DropMenuItemBox>
-        ) : (
-          <S.DropMenuItemBox onClick={onBlock}>차단</S.DropMenuItemBox>
-        )}
-        {banned && <S.DropMenuItemBox onClick={onUnban}>입장 금지 해제</S.DropMenuItemBox>}
-        {!banned &&
-          targetOper &&
-          (myOper === "owner" || (myOper === "admin" && targetOper === "participant")) && (
-            <>
-              {targetMuted ? (
-                <S.DropMenuItemBox disabled>음소거중</S.DropMenuItemBox>
-              ) : (
-                <S.DropMenuItemBox onClick={onMute}>음소거</S.DropMenuItemBox>
-              )}
-              <S.DropMenuItemBox onClick={onKick}>내보내기</S.DropMenuItemBox>
-              <S.DropMenuItemBox onClick={onBan}>입장 금지</S.DropMenuItemBox>
-            </>
+  switch (menuFor) {
+    case "friend":
+      return (
+        <ModalLayout ref={dropRef}>
+          <DefaultMenu />
+          <InviteGame />
+          <InviteChat />
+        </ModalLayout>
+      );
+    case "participant":
+      return (
+        <ModalLayout ref={dropRef}>
+          <DefaultMenu />
+          <InviteGame />
+          <BlockInChat />
+          {(myOper === "owner" || (myOper === "admin" && targetStatus?.oper === "participant")) && (
+            <ForAdminInChat />
           )}
-        {!banned &&
-          targetOper &&
-          myOper === "owner" &&
-          (targetOper === "admin" ? (
-            <S.DropMenuItemBox onClick={onDismissAdmin}>부방장 해제</S.DropMenuItemBox>
-          ) : (
-            <S.DropMenuItemBox onClick={onAppointAdmin}>부방장 지정</S.DropMenuItemBox>
-          ))}
-        {isOnline && myOper && myOper !== "participant" && !targetOper && !banned && (
-          <InviteBtn roomId={roomId} username={targetUser} close={onClose} />
-        )}
-      </S.DropMenuLayout>
-    </>
-  );
+          {myOper === "owner" && <ForOwnerInChat />}
+        </ModalLayout>
+      );
+    case "banned":
+      return (
+        <ModalLayout ref={dropRef}>
+          <DefaultMenu />
+          <UnBan />
+        </ModalLayout>
+      );
+    case "player":
+      return (
+        <ModalLayout ref={dropRef}>
+          <DefaultMenu />
+        </ModalLayout>
+      );
+    case "observer":
+      return (
+        <ModalLayout ref={dropRef}>
+          <DefaultMenu />
+          <InviteGame />
+        </ModalLayout>
+      );
+    default:
+      return null;
+  }
 }

--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -5,7 +5,7 @@ import { useOper, onProfile } from "hooks/useOper";
 import { UserListContext } from "hooks/context/UserListContext";
 import { useOutsideClick } from "hooks/useOutsideClick";
 import InviteBtn from "./InviteBtn";
-import * as T from "../rightSideType";
+import * as T from "@rightSide/rightSideType";
 import * as S from "./style";
 
 const ModalLayout = forwardRef(function ModalLayout(
@@ -34,7 +34,6 @@ export default function UserDropMenu({
   menuFor,
   targetUser,
   targetStatus,
-  subline,
 }: T.DropMenuProps) {
   const setProfileUser = useContext(ProfileContext);
   const myOper = useContext(UserListContext)?.myOper;
@@ -48,7 +47,6 @@ export default function UserDropMenu({
   const onUnban = useOper("unban", roomId, targetUser, onClose);
   const onBlock = useOper("block", roomId, targetUser, onClose);
   const onUnblock = useOper("unblock", roomId, targetUser, onClose);
-  const isOnline = subline?.split(" ")[1] === "온라인" ? true : false;
   useOutsideClick({ modalRef: dropRef, onClose });
 
   function handleDm() {
@@ -72,11 +70,15 @@ export default function UserDropMenu({
   };
 
   const InviteGame = () => {
-    return isOnline ? <S.DropMenuItemBox>게임 신청</S.DropMenuItemBox> : <></>;
+    return targetStatus?.status === "login" ? (
+      <S.DropMenuItemBox>게임 신청</S.DropMenuItemBox>
+    ) : (
+      <></>
+    );
   };
 
   const InviteChat = () => {
-    return myOper !== "participant" && isOnline ? (
+    return myOper !== "participant" && targetStatus?.status === "login" ? (
       <InviteBtn roomId={roomId} username={targetUser} close={onClose} />
     ) : (
       <></>

--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -54,110 +54,90 @@ export default function UserDropMenu({
     onClose();
   }
 
-  const DefaultMenu = () => {
-    return (
-      <>
-        <S.DropMenuItemBox
-          onClick={() => {
-            setProfileUser && onProfile(targetUser, setProfileUser, onClose);
-          }}
-        >
-          프로필
-        </S.DropMenuItemBox>
-        <S.DropMenuItemBox onClick={handleDm}>DM 보내기</S.DropMenuItemBox>
-      </>
-    );
-  };
+  const DefaultMenu = (
+    <>
+      <S.DropMenuItemBox
+        onClick={() => {
+          setProfileUser && onProfile(targetUser, setProfileUser, onClose);
+        }}
+      >
+        프로필
+      </S.DropMenuItemBox>
+      <S.DropMenuItemBox onClick={handleDm}>DM 보내기</S.DropMenuItemBox>
+    </>
+  );
 
-  const InviteGame = () => {
-    return targetStatus?.status === "login" ? (
-      <S.DropMenuItemBox>게임 신청</S.DropMenuItemBox>
-    ) : (
-      <></>
-    );
-  };
+  const InviteGame =
+    targetStatus?.status === "login" ? <S.DropMenuItemBox>게임 신청</S.DropMenuItemBox> : <></>;
 
-  const InviteChat = () => {
-    return myOper !== "participant" && targetStatus?.status === "login" ? (
+  const InviteChat =
+    myOper !== "participant" && targetStatus?.status === "login" ? (
       <InviteBtn roomId={roomId} username={targetUser} close={onClose} />
     ) : (
       <></>
     );
-  };
 
-  const BlockInChat = () => {
-    return targetStatus?.blocked ? (
-      <S.DropMenuItemBox onClick={onUnblock}>차단해제</S.DropMenuItemBox>
-    ) : (
-      <S.DropMenuItemBox onClick={onBlock}>차단</S.DropMenuItemBox>
-    );
-  };
+  const BlockInChat = targetStatus?.blocked ? (
+    <S.DropMenuItemBox onClick={onUnblock}>차단해제</S.DropMenuItemBox>
+  ) : (
+    <S.DropMenuItemBox onClick={onBlock}>차단</S.DropMenuItemBox>
+  );
 
-  const ForAdminInChat = () => {
-    return (
-      <>
-        {targetStatus?.muted ? (
-          <S.DropMenuItemBox disabled>음소거중</S.DropMenuItemBox>
-        ) : (
-          <S.DropMenuItemBox onClick={onMute}>음소거</S.DropMenuItemBox>
-        )}
-        <S.DropMenuItemBox onClick={onKick}>내보내기</S.DropMenuItemBox>
-        <S.DropMenuItemBox onClick={onBan}>입장 금지</S.DropMenuItemBox>
-      </>
-    );
-  };
+  const ForAdminInChat = (
+    <>
+      {targetStatus?.muted ? (
+        <S.DropMenuItemBox disabled>음소거중</S.DropMenuItemBox>
+      ) : (
+        <S.DropMenuItemBox onClick={onMute}>음소거</S.DropMenuItemBox>
+      )}
+      <S.DropMenuItemBox onClick={onKick}>내보내기</S.DropMenuItemBox>
+      <S.DropMenuItemBox onClick={onBan}>입장 금지</S.DropMenuItemBox>
+    </>
+  );
 
-  const ForOwnerInChat = () => {
-    return targetStatus?.oper === "admin" ? (
+  const ForOwnerInChat =
+    targetStatus?.oper === "admin" ? (
       <S.DropMenuItemBox onClick={onDismissAdmin}>부방장 해제</S.DropMenuItemBox>
     ) : (
       <S.DropMenuItemBox onClick={onAppointAdmin}>부방장 지정</S.DropMenuItemBox>
     );
-  };
 
-  const UnBan = () => {
-    return <S.DropMenuItemBox onClick={onUnban}>입장 금지 해제</S.DropMenuItemBox>;
-  };
+  const UnBan = <S.DropMenuItemBox onClick={onUnban}>입장 금지 해제</S.DropMenuItemBox>;
 
   switch (menuFor) {
     case "friend":
       return (
         <ModalLayout ref={dropRef}>
-          <DefaultMenu />
-          <InviteGame />
-          <InviteChat />
+          {DefaultMenu}
+          {InviteGame}
+          {InviteChat}
         </ModalLayout>
       );
     case "participant":
       return (
         <ModalLayout ref={dropRef}>
-          <DefaultMenu />
-          <InviteGame />
-          <BlockInChat />
-          {(myOper === "owner" || (myOper === "admin" && targetStatus?.oper === "participant")) && (
-            <ForAdminInChat />
-          )}
-          {myOper === "owner" && <ForOwnerInChat />}
+          {DefaultMenu}
+          {InviteGame}
+          {BlockInChat}
+          {(myOper === "owner" || (myOper === "admin" && targetStatus?.oper === "participant")) &&
+            ForAdminInChat}
+          {myOper === "owner" && ForOwnerInChat}
         </ModalLayout>
       );
     case "banned":
       return (
         <ModalLayout ref={dropRef}>
-          <DefaultMenu />
-          <UnBan />
+          {DefaultMenu}
+          {UnBan}
         </ModalLayout>
       );
     case "player":
-      return (
-        <ModalLayout ref={dropRef}>
-          <DefaultMenu />
-        </ModalLayout>
-      );
+      return <ModalLayout ref={dropRef}>{DefaultMenu}</ModalLayout>;
     case "observer":
       return (
         <ModalLayout ref={dropRef}>
-          <DefaultMenu />
-          <InviteGame />
+          {DefaultMenu}
+          {InviteGame}
         </ModalLayout>
       );
     default:

--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -1,17 +1,14 @@
-import { useEffect, useRef, useContext, useState, forwardRef } from "react";
+import { useEffect, useRef, useContext, forwardRef } from "react";
 import { useParams } from "react-router-dom";
 import { ProfileContext } from "hooks/context/ProfileContext";
 import { useOper, onProfile } from "hooks/useOper";
 import { UserListContext } from "hooks/context/UserListContext";
 import InviteBtn from "./InviteBtn";
+import * as T from "../rightSideType";
 import * as S from "./style";
 
-type ModalLayoutProps = {
-  children: React.ReactNode;
-};
-
 const ModalLayout = forwardRef(function ModalLayout(
-  props: ModalLayoutProps,
+  props: T.ModalLayoutProps,
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
   return (
@@ -22,21 +19,7 @@ const ModalLayout = forwardRef(function ModalLayout(
   );
 });
 
-type TargetStatusType = {
-  oper?: string;
-  muted?: boolean;
-  blocked?: boolean;
-};
-
-type DropMenuProps = {
-  onClose: () => void;
-  onDmOpen: () => void;
-  menuFor: string;
-  targetUser: string;
-  targetStatus?: TargetStatusType;
-  subline: string;
-};
-
+// TEST: 게임까지 구현 완료 후 삭제하기
 // 전체 필요한것 : onClose / onDmOpen / setProfile / menuFor(friend/participant/banned/player/observer) / targetUser
 // friend : 기본[프로필/게임신청/DM 보내기] + 채팅초대 : targetUser, isOnline(게임신청/채팅초대 block)
 // participant : 기본 + [차단] + 권한[음소거/내보내기/입장금지] + 방장[부방장 지정] : userOper, targetStatus(oper, muted, blocked, isOnline)
@@ -51,7 +34,7 @@ export default function UserDropMenu({
   targetUser,
   targetStatus,
   subline,
-}: DropMenuProps) {
+}: T.DropMenuProps) {
   const setProfileUser = useContext(ProfileContext);
   const roomId = Number(useParams().roomId);
   const dropRef = useRef<HTMLDivElement>(null);

--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useContext, forwardRef } from "react";
+import { useRef, useContext, forwardRef } from "react";
 import { useParams } from "react-router-dom";
 import { ProfileContext } from "hooks/context/ProfileContext";
 import { useOper, onProfile } from "hooks/useOper";
 import { UserListContext } from "hooks/context/UserListContext";
+import { useOutsideClick } from "hooks/useOutsideClick";
 import InviteBtn from "./InviteBtn";
 import * as T from "../rightSideType";
 import * as S from "./style";
@@ -36,9 +37,9 @@ export default function UserDropMenu({
   subline,
 }: T.DropMenuProps) {
   const setProfileUser = useContext(ProfileContext);
+  const myOper = useContext(UserListContext)?.myOper;
   const roomId = Number(useParams().roomId);
   const dropRef = useRef<HTMLDivElement>(null);
-  const myOper = useContext(UserListContext)?.myOper;
   const onAppointAdmin = useOper("appointAdmin", roomId, targetUser, onClose);
   const onDismissAdmin = useOper("dismissAdmin", roomId, targetUser, onClose);
   const onMute = useOper("mute", roomId, targetUser, onClose);
@@ -48,6 +49,12 @@ export default function UserDropMenu({
   const onBlock = useOper("block", roomId, targetUser, onClose);
   const onUnblock = useOper("unblock", roomId, targetUser, onClose);
   const isOnline = subline?.split(" ")[1] === "온라인" ? true : false;
+  useOutsideClick({ modalRef: dropRef, onClose });
+
+  function handleDm() {
+    onDmOpen();
+    onClose();
+  }
 
   const DefaultMenu = () => {
     return (
@@ -109,24 +116,6 @@ export default function UserDropMenu({
   const UnBan = () => {
     return <S.DropMenuItemBox onClick={onUnban}>입장 금지 해제</S.DropMenuItemBox>;
   };
-
-  function handleDm() {
-    onDmOpen();
-    onClose();
-  }
-
-  useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      console.log("클릭!", dropRef.current);
-      if (dropRef.current && e.target instanceof Element && !dropRef.current.contains(e.target))
-        onClose();
-    };
-
-    window.addEventListener("mousedown", handleClick);
-    return () => {
-      window.removeEventListener("mousedown", handleClick);
-    };
-  }, [dropRef]);
 
   switch (menuFor) {
     case "friend":

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -10,26 +10,16 @@ import { getUsername } from "userAuth";
 import { getSocket } from "socket/socket";
 import { ExitDmResultType } from "socket/active/dmEventType";
 import * as S from "./style";
+import { TargetStatusType } from "@rightSide/rightSideType";
 
 type UserInfoProps = {
   listOf: string;
   username: string;
-  userOper?: string;
   subLine: string;
-  muted?: boolean;
-  banned?: boolean;
-  blocked?: boolean;
+  userStatus?: TargetStatusType;
 };
 
-export default function UserInfo({
-  listOf,
-  username,
-  userOper,
-  subLine,
-  muted,
-  banned,
-  blocked,
-}: UserInfoProps) {
+export default function UserInfo({ listOf, username, subLine, userStatus }: UserInfoProps) {
   const me = getUsername() === username;
   const { onDropOpen, onDropClose, dropIsOpen } = useDropModal({
     listOf: listOf,
@@ -87,8 +77,8 @@ export default function UserInfo({
         <S.ProfileImg src={String(avatarQuery.data)} clickable={listOf === "dm"} />
       )}
       <S.UserInfoText clickable={listOf === "dm"}>
-        {username} {userOper === "owner" ? "👑" : userOper === "admin" ? "🎩" : ""}
-        {muted ? " 🤐" : ""} {blocked ? " 🚫" : ""}
+        {username} {userStatus?.oper === "owner" ? "👑" : userStatus?.oper === "admin" ? "🎩" : ""}
+        {userStatus?.muted ? " 🤐" : ""} {userStatus?.blocked ? " 🚫" : ""}
         <br />
         {listOf === "dm" ? "✉️ " : ""}
         {subLine}
@@ -101,8 +91,7 @@ export default function UserInfo({
           onDmOpen={onOpen}
           targetUser={username}
           menuFor={listOf}
-          targetStatus={{ oper: userOper, muted, blocked }}
-          subline={subLine}
+          targetStatus={userStatus}
         />
       )}
       {isOpen && (

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -8,11 +8,11 @@ import DmModal from "modal/DmModal";
 import UserDropMenu from "./UserDropMenu";
 import { getUsername } from "userAuth";
 import { getSocket } from "socket/socket";
-import * as S from "./style";
 import { ExitDmResultType } from "socket/active/dmEventType";
+import * as S from "./style";
 
 type UserInfoProps = {
-  listOf?: string;
+  listOf: string;
   username: string;
   userOper?: string;
   subLine: string;
@@ -100,11 +100,9 @@ export default function UserInfo({
           onClose={onDropClose}
           onDmOpen={onOpen}
           targetUser={username}
-          targetOper={userOper}
-          targetMuted={muted}
-          targetBlocked={blocked}
-          banned={banned}
-          subLine={subLine}
+          menuFor={listOf}
+          targetStatus={{ oper: userOper, muted, blocked }}
+          subline={subLine}
         />
       )}
       {isOpen && (

--- a/src/components/rightSide/user/UserList.tsx
+++ b/src/components/rightSide/user/UserList.tsx
@@ -6,6 +6,7 @@ import FriendList from "./FriendList";
 import { UserListContext } from "hooks/context/UserListContext";
 import * as S from "../style";
 
+// TODO: 게임 구현 후 타입 파일로 보내기
 type UserListCase =
   | { listOf: "friend" | "player" | "observer" }
   | { listOf: "dm"; list: DmListArray | null }

--- a/src/components/rightSide/user/UserList.tsx
+++ b/src/components/rightSide/user/UserList.tsx
@@ -32,10 +32,13 @@ export default function UserList(props: UserListCase) {
                 key={user.username}
                 listOf={props.listOf}
                 username={user.username}
-                userOper={user.owner ? "owner" : user.admin ? "admin" : "participant"}
                 subLine={user.status === "login" ? "🟣 온라인" : "⚫️ 오프라인"}
-                muted={user.muted ? true : false}
-                blocked={blocked}
+                userStatus={{
+                  status: user.status,
+                  oper: user.owner ? "owner" : user.admin ? "admin" : "participant",
+                  muted: user.muted,
+                  blocked,
+                }}
               />
             );
           })}
@@ -47,7 +50,6 @@ export default function UserList(props: UserListCase) {
                 listOf={props.listOf}
                 username={user.username}
                 subLine="❌ 입장금지"
-                banned
               />
             );
           })}

--- a/src/components/rightSide/user/style.tsx
+++ b/src/components/rightSide/user/style.tsx
@@ -27,7 +27,7 @@ export const LoadingImg = styled.img<{ clickable?: boolean }>`
   background-color: ${darkGray};
 `;
 
-export const ProfileImg = styled.img<{ clickable: boolean }>`
+export const ProfileImg = styled.img<{ clickable?: boolean }>`
   width: 50px;
   height: 50px;
   border-radius: 100%;
@@ -37,7 +37,7 @@ export const ProfileImg = styled.img<{ clickable: boolean }>`
   }}
 `;
 
-export const UserInfoText = styled.span<{ clickable: boolean }>`
+export const UserInfoText = styled.span<{ clickable?: boolean }>`
   max-width: 70%;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/hooks/useOper.ts
+++ b/src/hooks/useOper.ts
@@ -15,12 +15,11 @@ export function useOper(operator: string, roomId: number, targetUser: string, on
   const socket = getSocket();
 
   function handleResult(res: ChatRoomResponse) {
-    // TEST : 이벤트 결과 확인용
     if (res.status === "approved") {
       if (res.roomId === roomId) {
         onClose();
       }
-    } else console.log("오류", res);
+    } else console.log("oper error", res);
   }
 
   useEffect(() => {
@@ -31,8 +30,6 @@ export function useOper(operator: string, roomId: number, targetUser: string, on
   }, []);
 
   return function onOper() {
-    // TEST: 블락/언블락 테스트
-    console.log("emit 전송", roomId, targetUser);
     socket.emit(operator, {
       roomId,
       username: targetUser,

--- a/src/hooks/useOutsideClick.tsx
+++ b/src/hooks/useOutsideClick.tsx
@@ -15,5 +15,5 @@ export function useOutsideClick({ modalRef, onClose }: OutSideClickProps) {
     return () => {
       window.removeEventListener("mousedown", handleClose);
     };
-  }, []);
+  }, [modalRef]);
 }

--- a/src/modal/DmModal.tsx
+++ b/src/modal/DmModal.tsx
@@ -23,14 +23,11 @@ export default function DmModal({ targetUser, onClose }: DmModalProps) {
 
   function listener(res: T.DmHistoryData | T.DmResponse) {
     if (res.type === "history" && dmChat.length === 0) {
-      // TEST: DM 구현중
-      console.log("dm 히스토리", res);
       res.list.map((chat) => {
         setDmChat((prevChat) => [...prevChat, chat]);
       });
       setIsLoading(false);
     } else if (res.type === "dm") {
-      console.log("dm", res);
       setDmChat((prevChat) => [...prevChat, { from: res.from, content: res.content }]);
     }
   }
@@ -55,19 +52,15 @@ export default function DmModal({ targetUser, onClose }: DmModalProps) {
   }, [isLoading]);
 
   useEffect(() => {
-    console.log("마운트");
     socket.emit("subscribe", {
       type: "dm",
       username: targetUser,
     });
     socket.on("dmResult", (res) => {
-      console.log("dm 전송 결과", res);
-      // TEST: DM 전송에서 발생할 에러 핸들링
-      if (res.status !== "approved") console.log("DM 오류", res);
+      if (res.status !== "approved") console.log("DM error", res);
     });
 
     return () => {
-      console.log("언마운트");
       socket.emit("unsubscribe", {
         type: "dm",
         username: targetUser,

--- a/src/pages/auth/chat/room/ChatRoom.tsx
+++ b/src/pages/auth/chat/room/ChatRoom.tsx
@@ -28,9 +28,7 @@ export default function ChatRoom() {
   function handleChatRoom(
     res: T.ChatData | T.HistoryData | T.ChatRoomData | T.AffectedData | T.BlockData,
   ) {
-    // TEST: 채팅방 내 전체 이벤트 리스너
     if (res.roomId !== Number(roomId) || res.type === "chat") return;
-    console.log("채팅방", res);
     if (res.type === "chatRoom") {
       const myRoomInfo = res.userList.filter((user) => user.username === getUsername())[0];
       if (myRoomInfo?.owner) myOper.current = "owner";

--- a/src/socket/socket.ts
+++ b/src/socket/socket.ts
@@ -10,7 +10,7 @@ export function setSocket(token: string): Socket {
       Authorization: "Bearer " + token,
     },
   });
-  // 로그인 시 소켓 연결 확인용 로그
+  // TEST: 로그인 시 소켓 연결 확인용 로그
   console.log("init", socket);
   return socket;
 }
@@ -23,6 +23,7 @@ export function getSocket(): Socket {
 export function disconnectSocket() {
   if (socket) {
     socket.disconnect();
+    // TEST: 소켓 연결 끊어짐 확인용 로그
     console.log("disconnect", socket);
   }
 }


### PR DESCRIPTION
## 개요
- UserInfo/UserDropMenu 리팩토링

## 작업사항
- UserDropMenu / UserInfo / UserList 리팩토링
- 타입 별도 파일로 분리
- 테스트 끝난 콘솔 로그 삭제
- 구현된 커스텀 훅 사용하여 중복 코드 삭제

## 코멘트
- 최대한 가독성 고려하여 리팩토링 해보았습니다!!

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
