### PR TITLE
feat: username(id)/passwd 정책 설정 #98

### DIFF
--- a/src/pages/unauth/signUp/SignUp.tsx
+++ b/src/pages/unauth/signUp/SignUp.tsx
@@ -147,7 +147,7 @@ export default function signUp() {
             <h2>회원가입</h2>
             <S.InputArea>
               <S.BtnWrapper>
-                <S.Input placeholder="아이디" onChange={onIdHandler}></S.Input>
+                <S.Input placeholder="아이디" maxLength={10} onChange={onIdHandler}></S.Input>
                 <S.Button type="button" onClick={onCheckIdHandler}>
                   중복확인
                 </S.Button>

--- a/src/pages/unauth/signUp/SignUp.tsx
+++ b/src/pages/unauth/signUp/SignUp.tsx
@@ -53,6 +53,7 @@ export default function signUp() {
   function onPhoneHandler(event: eventChangeType) {
     setPhoneInput(event.target.value);
     if (phoneCheck) setPhoneCheck("");
+    if (sendAuthBtn) setSendAuthBtn(false);
   }
 
   function onPhoneAuthHandler(event: eventChangeType) {
@@ -184,9 +185,9 @@ export default function signUp() {
               <S.BtnWrapper>
                 <S.Input
                   placeholder="휴대폰 번호"
+                  type="tel"
                   required
                   onChange={onPhoneHandler}
-                  disabled={sendAuthBtn}
                 ></S.Input>
                 <S.Button type="button" onClick={sendPhoneAuthHandler} disabled={sendAuthBtn}>
                   인증번호 받기

--- a/src/pages/unauth/signUp/SignUp.tsx
+++ b/src/pages/unauth/signUp/SignUp.tsx
@@ -25,6 +25,7 @@ export default function signUp() {
   const [formCheck, setFormCheck] = useState("");
 
   const passwdRegExp = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,}$/;
+  const phoneRegExp = /^[0-9]{0,13}$/;
 
   function onIdHandler(event: eventChangeType) {
     setIdInput(event.target.value);
@@ -37,7 +38,7 @@ export default function signUp() {
     // TEST: 테스트 기간동안 주석 처리 / 패스워드 정책 확인
     if (event.target.value === "") setPwRuleCheck("");
     else if (passwdRegExp.test(event.target.value)) setPwRuleCheck("");
-    else setPwRuleCheck("영문, 숫자, 특수문자 조합으로 8자 이상 입력해주세요.");
+    else setPwRuleCheck("영문, 숫자, 특수문자 조합으로 8자 이상 입력해 주세요.");
 
     if (formCheck) setFormCheck("");
     if (pwMatchCheck) setPwMatchCheck("");
@@ -51,8 +52,10 @@ export default function signUp() {
   }
 
   function onPhoneHandler(event: eventChangeType) {
-    setPhoneInput(event.target.value);
-    if (phoneCheck) setPhoneCheck("");
+    if (phoneRegExp.test(event.target.value)) {
+      setPhoneCheck("");
+      setPhoneInput(event.target.value);
+    } else setPhoneCheck("하이픈(-) 없이 숫자만 입력해 주세요.");
     if (sendAuthBtn) setSendAuthBtn(false);
   }
 
@@ -185,7 +188,7 @@ export default function signUp() {
               <S.BtnWrapper>
                 <S.Input
                   placeholder="휴대폰 번호"
-                  type="tel"
+                  value={phoneInput}
                   required
                   onChange={onPhoneHandler}
                 ></S.Input>

--- a/src/pages/unauth/signUp/SignUp.tsx
+++ b/src/pages/unauth/signUp/SignUp.tsx
@@ -178,6 +178,7 @@ export default function signUp() {
                   required
                   type="password"
                   onChange={onPwMatchCheckHandler}
+                  disabled={pwInput.length === 0 || pwRuleCheck !== ""}
                 ></S.Input1>
               </S.BtnWrapper>
               <S.Span color={pwMatchCheck === "패스워드가 일치합니다." ? "green" : "red"}>

--- a/src/pages/unauth/signUp/SignUp.tsx
+++ b/src/pages/unauth/signUp/SignUp.tsx
@@ -13,7 +13,8 @@ export default function signUp() {
   const [idInput, setIdInput] = useState("");
   const [idCheck, setIdCheck] = useState("");
   const [pwInput, setPwInput] = useState("");
-  const [pwCheck, setPwCheck] = useState("");
+  const [pwRuleCheck, setPwRuleCheck] = useState("");
+  const [pwMatchCheck, setPwMatchCheck] = useState("");
   const [phoneInput, setPhoneInput] = useState("");
   const [phoneAuthInput, setPhoneAuthInput] = useState("");
   const [sendAuthBtn, setSendAuthBtn] = useState(false);
@@ -23,6 +24,8 @@ export default function signUp() {
   const [checkAuthBtn, setCheckAuthBtn] = useState(true);
   const [formCheck, setFormCheck] = useState("");
 
+  const passwdRegExp = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,}$/;
+
   function onIdHandler(event: eventChangeType) {
     setIdInput(event.target.value);
     if (formCheck) setFormCheck("");
@@ -31,14 +34,19 @@ export default function signUp() {
 
   function onPwHandler(event: eventChangeType) {
     setPwInput(event.target.value);
+    // TEST: 테스트 기간동안 주석 처리 / 패스워드 정책 확인
+    if (event.target.value === "") setPwRuleCheck("");
+    else if (passwdRegExp.test(event.target.value)) setPwRuleCheck("");
+    else setPwRuleCheck("영문, 숫자, 특수문자 조합으로 8자 이상 입력해주세요.");
+
     if (formCheck) setFormCheck("");
-    if (pwCheck) setPwCheck("");
+    if (pwMatchCheck) setPwMatchCheck("");
   }
 
-  function onPwCheckHandler(event: eventChangeType) {
-    setPwCheck("패스워드가 일치하지 않습니다.");
+  function onPwMatchCheckHandler(event: eventChangeType) {
+    setPwMatchCheck("패스워드가 일치하지 않습니다.");
     if (pwInput == event.target.value) {
-      setPwCheck("패스워드가 일치합니다.");
+      setPwMatchCheck("패스워드가 일치합니다.");
     }
   }
 
@@ -93,7 +101,7 @@ export default function signUp() {
     event.preventDefault();
     if (
       idCheck === "사용 가능한 아이디입니다." &&
-      pwCheck === "패스워드가 일치합니다." &&
+      pwMatchCheck === "패스워드가 일치합니다." &&
       phoneAuthCheck === "인증완료"
     ) {
       const userInfo: user.userInfoType = {
@@ -110,7 +118,8 @@ export default function signUp() {
       }
     } else {
       if (!(idCheck === "사용 가능한 아이디입니다.")) setFormCheck("아이디를 확인해주세요.");
-      else if (!(pwCheck === "패스워드가 일치합니다.")) setFormCheck("패스워드를 확인해주세요.");
+      else if (!(pwMatchCheck === "패스워드가 일치합니다."))
+        setFormCheck("패스워드를 확인해주세요.");
       else if (!(phoneAuthCheck === "인증완료")) setFormCheck("휴대폰 인증을 해주세요.");
     }
   }
@@ -156,6 +165,7 @@ export default function signUp() {
                   onChange={onPwHandler}
                 ></S.Input1>
               </S.BtnWrapper>
+              <S.Span color="red">{pwRuleCheck}</S.Span>
             </S.InputArea>
             <S.InputArea>
               <S.BtnWrapper>
@@ -163,11 +173,11 @@ export default function signUp() {
                   placeholder="패스워드 확인"
                   required
                   type="password"
-                  onChange={onPwCheckHandler}
+                  onChange={onPwMatchCheckHandler}
                 ></S.Input1>
               </S.BtnWrapper>
-              <S.Span color={pwCheck === "패스워드가 일치합니다." ? "green" : "red"}>
-                {pwCheck}
+              <S.Span color={pwMatchCheck === "패스워드가 일치합니다." ? "green" : "red"}>
+                {pwMatchCheck}
               </S.Span>
             </S.InputArea>
             <S.InputArea>


### PR DESCRIPTION
## 개요
- username(id)/passwd 정책 설정

## 작업사항
- username 글자수 제한
- passwd 정책 설정
- 휴대폰 번호 숫자만 입력 가능하게

## 변경로직

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
