### PR TITLE
fix: DM 리스트 외에서 DM 모달 안뜨는 에러 #101

### DIFF
--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -99,6 +99,11 @@ export default function UserInfo({ listOf, username, subLine, userStatus }: T.Us
               targetStatus={userStatus}
             />
           )}
+          {isOpen && (
+            <Modal key={username}>
+              <DmModal targetUser={username} onClose={onClose} />
+            </Modal>
+          )}
         </S.UserItem>
       );
   }


### PR DESCRIPTION
## 개요
DM 리스트 외에서 DM 모달이 뜨지 않는 에러

## 작업사항
- `UserInfo`의 default case에도 DM 모달 로직 삽입

## 변경로직

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
