### PR TITLE
feat: 매치 메이킹 게임 화면 연동 #104 

### DIFF
--- a/src/modal/MatchGameModal.tsx
+++ b/src/modal/MatchGameModal.tsx
@@ -1,0 +1,72 @@
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import * as S from "./layout/style";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { getSocket } from "socket/socket";
+
+type modalProps = {
+  close: () => void;
+  notice: string;
+  setNotice: Dispatch<SetStateAction<string>>;
+};
+
+export default function MatchGameModal(props: modalProps) {
+  const [option, setOption] = useState("");
+  const socket = getSocket();
+  const navigate = useNavigate();
+
+  function setStatusHandler(e: React.ChangeEvent<HTMLSelectElement>) {
+    setOption(e.target.value);
+    if (props.notice) props.setNotice("");
+  }
+
+  const listener = (res: any) => {
+    console.log(res);
+    props.setNotice("");
+    if (res.status === "match") {
+      navigate(`/game/${res.roomId}`);
+    } else if (res.status === "searching") {
+      props.setNotice("게임 찾는 중...");
+    }
+  };
+
+  useEffect(() => {
+    socket.on("searchGameResult", listener);
+    return () => {
+      socket.off("searchGameResult", listener);
+    };
+  });
+
+  function setHandler(e: React.MouseEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (option) {
+      socket.emit("searchGame", {
+        rule: option,
+      });
+    } else {
+      props.setNotice("옵션을 선택해주세요.");
+    }
+  }
+
+  return (
+    <S.MatchGameLayout>
+      <h2>게임 매치 등록하기</h2>
+      <form onSubmit={setHandler}>
+        <S.Wrapper>
+          <select onChange={setStatusHandler}>
+            <option value="opt">-- 옵션을 선택해주세요 --</option>
+            <option value="normal">일반 게임</option>
+            <option value="rank">랭크 게임</option>
+            <option value="arcade">특별 게임</option>
+          </select>
+        </S.Wrapper>
+        <S.Span color="red">{props.notice}</S.Span>
+        <S.Wrapper>
+          <S.ModalButton2 type="submit">확인</S.ModalButton2>
+          <S.ModalButton2 type="button" onClick={props.close}>
+            취소
+          </S.ModalButton2>
+        </S.Wrapper>
+      </form>
+    </S.MatchGameLayout>
+  );
+}

--- a/src/modal/layout/style.tsx
+++ b/src/modal/layout/style.tsx
@@ -295,3 +295,16 @@ export const SettingPwLayout = styled.div`
   font-size: 12px;
   border-radius: 20px;
 `
+
+/* 
+  match game
+*/
+
+export const MatchGameLayout = styled.div`
+  position: relative;
+  width: 100%;
+  text-align: center;
+  background: white;
+  font-size: 12px;
+  border-radius: 20px;
+`

--- a/src/pages/auth/game/list/GameList.tsx
+++ b/src/pages/auth/game/list/GameList.tsx
@@ -3,10 +3,15 @@ import { isAuth } from "userAuth";
 import GameItem from "./GameItem";
 import * as S from "./style";
 import RightSide from "@rightSide/RightSide";
+import { useState } from "react";
+import Modal from "modal/layout/Modal";
+import MatchGameModal from "modal/MatchGameModal";
 
 export default function GameList() {
   const navigate = useNavigate();
   if (!isAuth()) navigate("/");
+  const [showModal, setShowModal] = useState(false);
+  const [notice, setNotice] = useState("");
 
   let gameCnt = 0;
   // 임시 더미데이터
@@ -27,19 +32,25 @@ export default function GameList() {
     },
   ];
 
+  const openModalHandler = () => {
+    setShowModal(true);
+  };
+
+  const closeModalHandler = () => {
+    setShowModal(false);
+  };
+
   return (
     <>
       <S.PageLayout>
+        {showModal && (
+          <Modal setView={closeModalHandler}>
+            <MatchGameModal close={closeModalHandler} notice={notice} setNotice={setNotice} />
+          </Modal>
+        )}
         <S.HeaderBox>
           <S.H2>진행중인 게임</S.H2>
-          <S.MatchMakingBtn
-            onClick={() => {
-              // TODO: 모달 띄우기
-              alert("매치메이킹 모달!");
-            }}
-          >
-            매치메이킹 등록
-          </S.MatchMakingBtn>
+          <S.MatchMakingBtn onClick={openModalHandler}>매치메이킹 등록</S.MatchMakingBtn>
         </S.HeaderBox>
         <S.GameList>
           <S.GameItem head>

--- a/src/pages/auth/game/room/GameRoom.tsx
+++ b/src/pages/auth/game/room/GameRoom.tsx
@@ -2,12 +2,158 @@ import { useParams, useNavigate } from "react-router-dom";
 import { isAuth } from "userAuth";
 import * as S from "./style";
 import RightSide from "@rightSide/RightSide";
+import { getSocket } from "socket/socket";
+import { useEffect, useRef, useState } from "react";
 
 export default function GameRoom() {
   const navigate = useNavigate();
   if (!isAuth()) navigate("/");
   const { gameId } = useParams();
   if (Number.isNaN(Number(gameId))) navigate("/404");
+  const socket = getSocket();
+  const [roomId, setRoomId] = useState(0);
+  const [ballX, setBallX] = useState(0);
+  const [ballY, setBallY] = useState(0);
+  const [ballRadius, setBallRadius] = useState(0);
+  const [blueWidth, setBlueWidth] = useState(0);
+  const [redWidth, setRedWidth] = useState(0);
+  const [blueHeight, setBlueHeight] = useState(0);
+  const [redHeight, setRedHeight] = useState(0);
+  const [blueY, setBlueY] = useState(0);
+  const [redY, setRedY] = useState(0);
+  const [blueX, setBlueX] = useState(0);
+  const [redX, setRedX] = useState(0);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvas = canvasRef.current;
+  const ctx = canvas?.getContext("2d");
+
+  const listener = (res: { type: string; status: any }) => {
+    if (res.status.roomId !== Number(gameId)) return;
+    if (res.type === "game") {
+      if (roomId !== res.status.roomId) setRoomId(res.status.roomId);
+      if (ballRadius === 0) setBallRadius(res.status.ballRadius);
+      if (redWidth === 0) setRedWidth(res.status.redPaddleWidth);
+      if (redHeight === 0) setRedHeight(res.status.bluePaddleHeight);
+      if (blueWidth === 0) setBlueWidth(res.status.bluePaddleWidth);
+      if (blueHeight === 0) setBlueHeight(res.status.bluePaddleHeight);
+      if (redX === 0) setRedX(res.status.redPaddleX);
+      if (blueX === 0) setBlueX(res.status.bluePaddleX);
+      setBallX(res.status.ballX);
+      setBallY(res.status.ballY);
+      setBlueY(res.status.bluePaddleY);
+      setRedY(res.status.redPaddleY);
+    } else {
+      console.log(res);
+    }
+  };
+
+  const keyDownHandler = (e: KeyboardEvent) => {
+    if (e.keyCode === 38) {
+      socket.emit("up", {
+        roomId: roomId,
+        role: "red",
+      });
+    } else if (e.keyCode === 40) {
+      socket.emit("down", {
+        roomId: roomId,
+        role: "red",
+      });
+    }
+    if (e.keyCode === 87) {
+      socket.emit("up", {
+        roomId: roomId,
+        role: "blue",
+      });
+    } else if (e.keyCode === 83) {
+      socket.emit("down", {
+        roomId: roomId,
+        role: "blue",
+      });
+    }
+  };
+
+  const keyUpHandler = (e: KeyboardEvent) => {
+    if (e.keyCode === 38) {
+      console.log(e.keyCode); // 방향키 위 : 38, 방향키 아래 : 40, 'w' : 87, 's': 83, esc : 27
+    } else if (e.keyCode === 40) {
+      console.log(e.keyCode);
+    }
+    if (e.keyCode === 87) {
+      console.log(e.keyCode);
+    } else if (e.keyCode === 83) {
+      console.log(e.keyCode);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("keydown", keyDownHandler, false);
+    document.addEventListener("keyup", keyUpHandler, false);
+    return () => {
+      document.removeEventListener("keydown", keyDownHandler, false);
+      document.removeEventListener("keyup", keyUpHandler, false);
+    };
+  }, [roomId]);
+
+  const drawBall = (ballX: number, ballY: number, ballRadius: number) => {
+    if (ctx) {
+      ctx.beginPath();
+      ctx.arc(ballX, ballY, ballRadius, 0, Math.PI * 2);
+      ctx.fillStyle = "#000000";
+      ctx.fill();
+      ctx.closePath();
+    }
+  };
+
+  function drawBluePaddle(x: number, y: number, width: number, height: number) {
+    if (ctx) {
+      ctx.beginPath();
+      ctx.rect(x, y, width, height);
+      ctx.fillStyle = "#0095DD";
+      ctx.fill();
+      ctx.closePath();
+    }
+  }
+
+  function drawRedPaddle(x: number, y: number, width: number, height: number) {
+    if (ctx && canvas) {
+      ctx.beginPath();
+      ctx.rect(x, y, width, height);
+      ctx.fillStyle = "#FF0088";
+      ctx.fill();
+      ctx.closePath();
+    }
+  }
+  useEffect(() => {
+    if (ctx && canvas) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height); //clear
+      drawBall(ballX, ballY, ballRadius);
+      drawBluePaddle(blueX, blueY, blueWidth, blueHeight);
+      drawRedPaddle(redX, redY, redWidth, blueHeight);
+    }
+  }, [ballX, ballY, redY, blueY]);
+
+  useEffect(() => {
+    socket.on("message", listener);
+    socket.on("exitGameRoomResult", listener);
+    //socket.emit("subscribe", {
+    //  type: "gameRoom",
+    //  roomId: roomId
+    //});
+    return () => {
+      socket.off("message", listener);
+      socket.off("exitGameRoomResult", listener);
+      //socket.emit("unsubscribe", {
+      //  type: "gameRoom",
+      //  roomId: roomId
+      //});
+    };
+  }, [roomId]);
+
+  const exitGameHandler = () => {
+    socket.emit("exitGameRoom", {
+      roomId: roomId,
+    });
+  };
 
   return (
     <>
@@ -15,6 +161,8 @@ export default function GameRoom() {
         <S.HeaderBox>
           <S.H2>{gameId}번 게임방 접속 완료</S.H2>
         </S.HeaderBox>
+        <button onClick={exitGameHandler}>나가기</button>
+        <S.Canvas ref={canvasRef} width={540} height={360}></S.Canvas>
       </S.PageLayout>
       <RightSide />
     </>

--- a/src/pages/auth/game/room/style.tsx
+++ b/src/pages/auth/game/room/style.tsx
@@ -21,3 +21,9 @@ export const H2 = styled.h2`
   margin: 0;
   padding: 5px 0;
 `;
+
+export const Canvas = styled.canvas`
+  background: #eee;
+  display: block;
+  margin: 0 auto;
+`


### PR DESCRIPTION
## 개요
- 매치 메이킹 & 게임 화면 연동

## 작업사항
- 매치 메이킹
  - 모달
  - searchGame 연동 -> normal 만 확인
- gameRoom
  - 화면
    - 공, 패들 위치 값 연동 
    - 패들 y 값 범위 서버에서 작업)
  - 패들 이동키 ( w, s, 상, 하) 이벤트 연동
  - 나기기 버튼

## comment
게임방이 만들어지고 화면이 작동되는거 까지만 연동되어있습니다. 전반적인 구조만 연동된 상태입니다 감안해서 봐주시면 감사하겠습니다,
<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->