### PR TITLE
feat: 게임 스코어 및 결과 나가기, 게임 신청 #106

### DIFF
--- a/src/components/rightSide/MyProfile.tsx
+++ b/src/components/rightSide/MyProfile.tsx
@@ -50,7 +50,7 @@ export default function MyProfile() {
         >
           {profileQuery?.data?.username}
           <br />
-          🟣 온라인
+          {profileQuery?.data?.status === "login" ? "🟣 온라인" : profileQuery?.data?.status === "logout" ? "⚫️ 오프라인" : "⚫️ 게임중"}
         </S.UserInfoText>
         {newNoti ? (
           <S.NewNotiIcon onClick={onOpenNotiModal} />

--- a/src/components/rightSide/rightSideType.ts
+++ b/src/components/rightSide/rightSideType.ts
@@ -19,6 +19,7 @@ export type TargetStatusType = {
 export type DropMenuProps = {
   onClose: () => void;
   onDmOpen: () => void;
+  onInviteGameOpen: () => void;
   menuFor: string;
   targetUser: string;
   targetStatus?: TargetStatusType;

--- a/src/components/rightSide/user/FriendList.tsx
+++ b/src/components/rightSide/user/FriendList.tsx
@@ -43,7 +43,7 @@ export default function FriendList(props: { listOf: string }) {
             key={user.username}
             listOf={props.listOf}
             username={user.username}
-            subLine={user.status === "login" ? "🟣 온라인" : "⚫️ 오프라인"}
+            subLine={user.status === "login" ? "🟣 온라인" : user.status === "logout" ? "⚫️ 오프라인" : "⚫️ 게임중"}
             userStatus={{ status: user.status }}
           />
         );

--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -77,7 +77,7 @@ export default function UserDropMenu({
     targetStatus?.status === "login" ? <S.DropMenuItemBox onClick={handleInviteGame}>게임 신청</S.DropMenuItemBox> : <></>;
 
   const InviteChat =
-    myOper !== "participant" && targetStatus?.status === "login" ? (
+    roomId && myOper !== "participant" && targetStatus?.status === "login" ? (
       <InviteBtn roomId={roomId} username={targetUser} close={onClose} />
     ) : (
       <></>

--- a/src/components/rightSide/user/UserDropMenu.tsx
+++ b/src/components/rightSide/user/UserDropMenu.tsx
@@ -31,6 +31,7 @@ const ModalLayout = forwardRef(function ModalLayout(
 export default function UserDropMenu({
   onClose,
   onDmOpen,
+  onInviteGameOpen,
   menuFor,
   targetUser,
   targetStatus,
@@ -54,6 +55,11 @@ export default function UserDropMenu({
     onClose();
   }
 
+  function handleInviteGame() {
+    onInviteGameOpen();
+    onClose();
+  }
+
   const DefaultMenu = (
     <>
       <S.DropMenuItemBox
@@ -68,7 +74,7 @@ export default function UserDropMenu({
   );
 
   const InviteGame =
-    targetStatus?.status === "login" ? <S.DropMenuItemBox>게임 신청</S.DropMenuItemBox> : <></>;
+    targetStatus?.status === "login" ? <S.DropMenuItemBox onClick={handleInviteGame}>게임 신청</S.DropMenuItemBox> : <></>;
 
   const InviteChat =
     myOper !== "participant" && targetStatus?.status === "login" ? (

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -12,7 +12,7 @@ import { ExitDmResultType } from "socket/active/dmEventType";
 import * as T from "@rightSide/rightSideType";
 import * as S from "./style";
 import InviteGameModal from "modal/InviteGameModal";
-import useInviteGameModal from "hooks/useInviteGameModal";
+import useGameModal from "hooks/useGameModal";
 
 export default function UserInfo({ listOf, username, subLine, userStatus }: T.UserInfoProps) {
   const me = getUsername() === username;
@@ -21,7 +21,7 @@ export default function UserInfo({ listOf, username, subLine, userStatus }: T.Us
   const { isMouseEnter, onLeave } = useMouseOver({ listOf, user: username });
   const queryClient = useQueryClient();
   const socket = getSocket();
-  const InviteGame = useInviteGameModal();
+  const InviteGame = useGameModal();
 
   const avatarQuery = useQuery({
     queryKey: ["avatar", `${username}`],
@@ -110,9 +110,9 @@ export default function UserInfo({ listOf, username, subLine, userStatus }: T.Us
           )}
           {
             InviteGame.isOpen && (
-              <InviteGame.InviteModal key={username}>
+              <InviteGame.GameModal key={username}>
                 <InviteGameModal targetUser={username} close={InviteGame.onClose} />
-              </InviteGame.InviteModal>
+              </InviteGame.GameModal>
             )
           }
         </S.UserItem>

--- a/src/components/rightSide/user/UserInfo.tsx
+++ b/src/components/rightSide/user/UserInfo.tsx
@@ -11,6 +11,8 @@ import { getSocket } from "socket/socket";
 import { ExitDmResultType } from "socket/active/dmEventType";
 import * as T from "@rightSide/rightSideType";
 import * as S from "./style";
+import InviteGameModal from "modal/InviteGameModal";
+import useInviteGameModal from "hooks/useInviteGameModal";
 
 export default function UserInfo({ listOf, username, subLine, userStatus }: T.UserInfoProps) {
   const me = getUsername() === username;
@@ -19,6 +21,7 @@ export default function UserInfo({ listOf, username, subLine, userStatus }: T.Us
   const { isMouseEnter, onLeave } = useMouseOver({ listOf, user: username });
   const queryClient = useQueryClient();
   const socket = getSocket();
+  const InviteGame = useInviteGameModal();
 
   const avatarQuery = useQuery({
     queryKey: ["avatar", `${username}`],
@@ -94,6 +97,7 @@ export default function UserInfo({ listOf, username, subLine, userStatus }: T.Us
             <UserDropMenu
               onClose={onDropClose}
               onDmOpen={onOpen}
+              onInviteGameOpen={InviteGame.onOpen}
               targetUser={username}
               menuFor={listOf}
               targetStatus={userStatus}
@@ -104,6 +108,13 @@ export default function UserInfo({ listOf, username, subLine, userStatus }: T.Us
               <DmModal targetUser={username} onClose={onClose} />
             </Modal>
           )}
+          {
+            InviteGame.isOpen && (
+              <InviteGame.InviteModal key={username}>
+                <InviteGameModal targetUser={username} close={InviteGame.onClose} />
+              </InviteGame.InviteModal>
+            )
+          }
         </S.UserItem>
       );
   }

--- a/src/components/rightSide/user/UserList.tsx
+++ b/src/components/rightSide/user/UserList.tsx
@@ -33,7 +33,7 @@ export default function UserList(props: UserListCase) {
                 key={user.username}
                 listOf={props.listOf}
                 username={user.username}
-                subLine={user.status === "login" ? "🟣 온라인" : "⚫️ 오프라인"}
+                subLine={user.status === "login" ? "🟣 온라인" : user.status === "logout" ? "⚫️ 오프라인" : "⚫️ 게임중"}
                 userStatus={{
                   status: user.status,
                   oper: user.owner ? "owner" : user.admin ? "admin" : "participant",

--- a/src/hooks/useGameModal.tsx
+++ b/src/hooks/useGameModal.tsx
@@ -2,7 +2,8 @@ import { useState } from "react";
 import Modal from "modal/layout/Modal";
 
 type ModalProps = {
-  children: React.ReactElement
+  children: React.ReactElement;
+  back?: string;
 };
 
 export default function useGameModal() {
@@ -18,7 +19,7 @@ export default function useGameModal() {
 
   function GameModal(props: ModalProps) {
     return (
-      <Modal setView={onOpen}>
+      <Modal setView={onOpen} back={props.back}>
         {props.children}
       </Modal>
     );

--- a/src/hooks/useGameModal.tsx
+++ b/src/hooks/useGameModal.tsx
@@ -5,7 +5,7 @@ type ModalProps = {
   children: React.ReactElement
 };
 
-export default function useInviteGameModal() {
+export default function useGameModal() {
   const [isOpen, setIsOpen] = useState(false);
 
   function onOpen() {
@@ -16,7 +16,7 @@ export default function useInviteGameModal() {
     setIsOpen(false);
   }
 
-  function InviteModal(props: ModalProps) {
+  function GameModal(props: ModalProps) {
     return (
       <Modal setView={onOpen}>
         {props.children}
@@ -25,7 +25,7 @@ export default function useInviteGameModal() {
   }
 
   return {
-    InviteModal,
+    GameModal,
     isOpen,
     onOpen,
     onClose,

--- a/src/hooks/useInviteGameModal.tsx
+++ b/src/hooks/useInviteGameModal.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import Modal from "modal/layout/Modal";
+
+type ModalProps = {
+  children: React.ReactElement
+};
+
+export default function useInviteGameModal() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  function onOpen() {
+    setIsOpen(true);
+  }
+
+  function onClose() {
+    setIsOpen(false);
+  }
+
+  function InviteModal(props: ModalProps) {
+    return (
+      <Modal setView={onOpen}>
+        {props.children}
+      </Modal>
+    );
+  }
+
+  return {
+    InviteModal,
+    isOpen,
+    onOpen,
+    onClose,
+  };
+}

--- a/src/hooks/useNotiModal.tsx
+++ b/src/hooks/useNotiModal.tsx
@@ -4,11 +4,13 @@ import Modal from "modal/layout/Modal";
 import NotificationModal from "modal/NotificationModal";
 
 export type NotiType = {
+  type: string;
   title: string;
   chatId?: number;
   chatTitle?: string;
   dmId?: number;
   gameId?: number;
+  from?: string;
 };
 
 type InvitationType = {
@@ -28,6 +30,7 @@ export default function useNotiModal(status: string) {
       setNoti((prev) => [
         ...prev,
         {
+          type: "chat",
           title: `${res.from} 님으로 부터 #${res.roomId} 채팅방에 초대 되었습니다.`,
           chatId: res.roomId,
           chatTitle: "초대된 ",
@@ -35,6 +38,17 @@ export default function useNotiModal(status: string) {
       ]);
       setNewNoti(true);
       if (status === "login") setShowNotiModal(true); // 게임 중 일때는 팝업 x
+    } else if (res.type === "gameInvitation") {
+      setNoti((prev) => [
+        ...prev,
+        {
+          type: "game",
+          title: `${res.from} 님으로 부터 게임 신청이 왔습니다.`,
+          from: res.from,
+        },
+      ]);
+      setNewNoti(true);
+      if (status === "login") setShowNotiModal(true);
     }
   };
 

--- a/src/modal/AcceptGameModal.tsx
+++ b/src/modal/AcceptGameModal.tsx
@@ -17,7 +17,7 @@ export default function AcceptGameModal(props: modalProps) {
   const acceptListener = (res: any) => {
     console.log("accept", res);
     if (res.status === "approved") {
-      //navigate() // 서버 gameroomId 미구현
+      navigate(`/game/${res.roomId}`)
       props.close();
       props.parentClose();
     }

--- a/src/modal/AcceptGameModal.tsx
+++ b/src/modal/AcceptGameModal.tsx
@@ -17,9 +17,13 @@ export default function AcceptGameModal(props: modalProps) {
   const acceptListener = (res: any) => {
     console.log("accept", res);
     if (res.status === "approved") {
-      navigate(`/game/${res.roomId}`)
+      navigate(`/game/${res.roomId}`);
       props.close();
       props.parentClose();
+    } else if (res.status === "warning") {
+      setNotice(res.detail);
+    } else {
+      console.log(res);
     }
   };
 
@@ -27,6 +31,10 @@ export default function AcceptGameModal(props: modalProps) {
     console.log("decline", res);
     if (res.status === "approved") {
       props.close();
+    } else if (res.status === "warning") {
+      setNotice(res.detail);
+    } else {
+      console.log(res);
     }
   };
 
@@ -40,23 +48,29 @@ export default function AcceptGameModal(props: modalProps) {
   }, []);
 
   const acceptHandler = () => {
-    socket.emit("acceptGame", {
-      username: props.targetUser,
-    });
-    //props.close();
-    //props.parentClose();
+    if (notice) {
+      props.close();
+    } else {
+      socket.emit("acceptGame", {
+        username: props.targetUser,
+      });
+    }
   };
 
   const declineHandler = () => {
-    //props.close();
-    socket.emit("declineGame", {
-      username: props.targetUser,
-    });
+    if (notice) {
+      props.close();
+    } else {
+      socket.emit("declineGame", {
+        username: props.targetUser,
+      });
+    }
   };
 
   return (
     <S.AcceptGameLayout>
       <h2>{props.targetUser}님의 게임 수락하시겠습니까?</h2>
+      <S.Span2 color="red">{notice}</S.Span2>
       <S.Wrapper>
         <S.ModalButton2 onClick={acceptHandler}>확인</S.ModalButton2>
         <S.ModalButton2 onClick={declineHandler}>취소</S.ModalButton2>

--- a/src/modal/AcceptGameModal.tsx
+++ b/src/modal/AcceptGameModal.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import * as S from "./layout/style";
+import { useNavigate } from "react-router-dom";
+import { getSocket } from "socket/socket";
+
+type modalProps = {
+  close: () => void;
+  parentClose: () => void;
+  targetUser: string;
+};
+
+export default function AcceptGameModal(props: modalProps) {
+  const [notice, setNotice] = useState("");
+  const socket = getSocket();
+  const navigate = useNavigate();
+
+  const acceptListener = (res: any) => {
+    console.log("accept", res);
+    if (res.status === "approved") {
+      //navigate() // 서버 gameroomId 미구현
+      props.close();
+      props.parentClose();
+    }
+  };
+
+  const declineListener = (res: any) => {
+    console.log("decline", res);
+    if (res.status === "approved") {
+      props.close();
+    }
+  };
+
+  useEffect(() => {
+    socket.on("acceptGameResult", acceptListener);
+    socket.on("declineGameResult", declineListener);
+    return () => {
+      socket.off("acceptGameResult", acceptListener);
+      socket.off("declineGameResult", declineListener);
+    };
+  }, []);
+
+  const acceptHandler = () => {
+    socket.emit("acceptGame", {
+      username: props.targetUser,
+    });
+    //props.close();
+    //props.parentClose();
+  };
+
+  const declineHandler = () => {
+    //props.close();
+    socket.emit("declineGame", {
+      username: props.targetUser,
+    });
+  };
+
+  return (
+    <S.AcceptGameLayout>
+      <h2>{props.targetUser}님의 게임 수락하시겠습니까?</h2>
+      <S.Wrapper>
+        <S.ModalButton2 onClick={acceptHandler}>확인</S.ModalButton2>
+        <S.ModalButton2 onClick={declineHandler}>취소</S.ModalButton2>
+      </S.Wrapper>
+    </S.AcceptGameLayout>
+  );
+}

--- a/src/modal/InviteGameModal.tsx
+++ b/src/modal/InviteGameModal.tsx
@@ -34,7 +34,7 @@ export default function InviteGameModal(props: modalProps) {
     if (res.status === "waiting") {
       setNotice(`${res.username}님 수락 기다리는 중...`);
     } else if (res.status === "accept") {
-      //navigate(`/game/${res.roomId}`); // game roomId x
+      navigate(`/game/${res.roomId}`);
     } else if (res.status === "decline") {
       setNotice(`${res.username}님과의 게임이 성사되지 않았습니다.`);
     }

--- a/src/modal/InviteGameModal.tsx
+++ b/src/modal/InviteGameModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import * as S from "./layout/style";
 import { useNavigate } from "react-router-dom";
 import { getSocket } from "socket/socket";
+import LoadingCircle from "components/LoadingCircle";
 
 type modalProps = {
   close: () => void;
@@ -48,6 +49,8 @@ export default function InviteGameModal(props: modalProps) {
 
   function setHandler(e: React.MouseEvent<HTMLFormElement>) {
     e.preventDefault();
+    setNotice("");
+    setStatus("waiting");
     if (option) {
       socket.emit("inviteGame", {
         username: props.targetUser,
@@ -70,7 +73,10 @@ export default function InviteGameModal(props: modalProps) {
             <option value="arcade">특별 게임</option>
           </select>
         </S.Wrapper>
-        <S.Span color="red">{notice}</S.Span>
+        <S.Wrapper>
+          <S.Span2 color="red">{notice}</S.Span2>
+          {notice && status === "waiting" && <LoadingCircle w={30} h={30} />}
+        </S.Wrapper>
         <S.Wrapper>
           <S.ModalButton2 type="submit" disabled={status === "waiting"}>
             확인

--- a/src/modal/InviteGameModal.tsx
+++ b/src/modal/InviteGameModal.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import * as S from "./layout/style";
+import { useNavigate } from "react-router-dom";
+import { getSocket } from "socket/socket";
+
+type modalProps = {
+  close: () => void;
+  targetUser: string;
+};
+
+export default function InviteGameModal(props: modalProps) {
+  const [option, setOption] = useState("");
+  const [notice, setNotice] = useState("");
+  const socket = getSocket();
+  const navigate = useNavigate();
+
+  function setStatusHandler(e: React.ChangeEvent<HTMLSelectElement>) {
+    setOption(e.target.value);
+    if (notice) setNotice("");
+  }
+
+  const listener = (res: any) => {
+    console.log(res);
+    setNotice("");
+    if (res.status === "match") {
+      navigate(`/game/${res.roomId}`);
+    } else if (res.status === "searching") {
+      setNotice("게임 수락 대기 중...");
+    } else if (res.status === "error") {
+      alert(res.detail);
+    }
+  };
+
+  useEffect(() => {
+    socket.on("inviteGameResult", listener);
+    return () => {
+      socket.off("inviteGameResult", listener);
+    };
+  });
+
+  function setHandler(e: React.MouseEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (option) {
+      socket.emit("inviteGame", {
+        username: props.targetUser,
+        rule: option,
+      });
+    } else {
+      setNotice("옵션을 선택해주세요.");
+    }
+  }
+
+  return (
+    <S.MatchGameLayout>
+      <h2>{props.targetUser} 에게 게임 신청 하기</h2>
+      <form onSubmit={setHandler}>
+        <S.Wrapper>
+          <select onChange={setStatusHandler}>
+            <option value="opt">-- 옵션을 선택해주세요 --</option>
+            <option value="normal">일반 게임</option>
+            <option value="rank">랭크 게임</option>
+            <option value="arcade">특별 게임</option>
+          </select>
+        </S.Wrapper>
+        <S.Span color="red">{notice}</S.Span>
+        <S.Wrapper>
+          <S.ModalButton2 type="submit">확인</S.ModalButton2>
+          <S.ModalButton2 type="button" onClick={props.close}>
+            취소
+          </S.ModalButton2>
+        </S.Wrapper>
+      </form>
+    </S.MatchGameLayout>
+  );
+}

--- a/src/modal/InviteGameModal.tsx
+++ b/src/modal/InviteGameModal.tsx
@@ -22,20 +22,20 @@ export default function InviteGameModal(props: modalProps) {
 
   const listener = (res: any) => {
     console.log(res);
-    
+
     setStatus(res.status);
     if (res.status === "error") {
       alert(res.detail);
     } else if (res.status === "warning") {
       setNotice(res.detail);
     }
-    if (res.username !== props.targetUser) return ;
+    if (res.username !== props.targetUser) return;
     if (res.status === "waiting") {
       setNotice(`${res.username}님 수락 기다리는 중...`);
     } else if (res.status === "accept") {
       //navigate(`/game/${res.roomId}`); // game roomId x
     } else if (res.status === "decline") {
-      setNotice(`${res.username}님과의 게임이 성사되지 않았습니다.`)
+      setNotice(`${res.username}님과의 게임이 성사되지 않았습니다.`);
     }
   };
 
@@ -63,7 +63,7 @@ export default function InviteGameModal(props: modalProps) {
       <h2>{props.targetUser} 에게 게임 신청 하기</h2>
       <form onSubmit={setHandler}>
         <S.Wrapper>
-          <select onChange={setStatusHandler}>
+          <select onChange={setStatusHandler} disabled={status === "waiting"}>
             <option value="opt">-- 옵션을 선택해주세요 --</option>
             <option value="normal">일반 게임</option>
             <option value="rank">랭크 게임</option>
@@ -72,7 +72,9 @@ export default function InviteGameModal(props: modalProps) {
         </S.Wrapper>
         <S.Span color="red">{notice}</S.Span>
         <S.Wrapper>
-          <S.ModalButton2 type="submit" disabled={status === "waiting"}>확인</S.ModalButton2>
+          <S.ModalButton2 type="submit" disabled={status === "waiting"}>
+            확인
+          </S.ModalButton2>
           <S.ModalButton2 type="button" disabled={status === "waiting"} onClick={props.close}>
             취소
           </S.ModalButton2>

--- a/src/modal/InviteGameModal.tsx
+++ b/src/modal/InviteGameModal.tsx
@@ -22,16 +22,20 @@ export default function InviteGameModal(props: modalProps) {
 
   const listener = (res: any) => {
     console.log(res);
-    if (res.username !== props.targetUser) return ;
+    
     setStatus(res.status);
+    if (res.status === "error") {
+      alert(res.detail);
+    } else if (res.status === "warning") {
+      setNotice(res.detail);
+    }
+    if (res.username !== props.targetUser) return ;
     if (res.status === "waiting") {
       setNotice(`${res.username}님 수락 기다리는 중...`);
     } else if (res.status === "accept") {
       //navigate(`/game/${res.roomId}`); // game roomId x
     } else if (res.status === "decline") {
       setNotice(`${res.username}님과의 게임이 성사되지 않았습니다.`)
-    } else if (res.status === "error") {
-      alert(res.detail);
     }
   };
 

--- a/src/modal/InviteGameModal.tsx
+++ b/src/modal/InviteGameModal.tsx
@@ -11,6 +11,7 @@ type modalProps = {
 export default function InviteGameModal(props: modalProps) {
   const [option, setOption] = useState("");
   const [notice, setNotice] = useState("");
+  const [status, setStatus] = useState("");
   const socket = getSocket();
   const navigate = useNavigate();
 
@@ -21,11 +22,14 @@ export default function InviteGameModal(props: modalProps) {
 
   const listener = (res: any) => {
     console.log(res);
-    setNotice("");
-    if (res.status === "match") {
-      navigate(`/game/${res.roomId}`);
-    } else if (res.status === "searching") {
-      setNotice("게임 수락 대기 중...");
+    if (res.username !== props.targetUser) return ;
+    setStatus(res.status);
+    if (res.status === "waiting") {
+      setNotice(`${res.username}님 수락 기다리는 중...`);
+    } else if (res.status === "accept") {
+      //navigate(`/game/${res.roomId}`); // game roomId x
+    } else if (res.status === "decline") {
+      setNotice(`${res.username}님과의 게임이 성사되지 않았습니다.`)
     } else if (res.status === "error") {
       alert(res.detail);
     }
@@ -64,8 +68,8 @@ export default function InviteGameModal(props: modalProps) {
         </S.Wrapper>
         <S.Span color="red">{notice}</S.Span>
         <S.Wrapper>
-          <S.ModalButton2 type="submit">확인</S.ModalButton2>
-          <S.ModalButton2 type="button" onClick={props.close}>
+          <S.ModalButton2 type="submit" disabled={status === "waiting"}>확인</S.ModalButton2>
+          <S.ModalButton2 type="button" disabled={status === "waiting"} onClick={props.close}>
             취소
           </S.ModalButton2>
         </S.Wrapper>

--- a/src/modal/MatchGameModal.tsx
+++ b/src/modal/MatchGameModal.tsx
@@ -1,31 +1,30 @@
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import * as S from "./layout/style";
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { getSocket } from "socket/socket";
 
 type modalProps = {
   close: () => void;
-  notice: string;
-  setNotice: Dispatch<SetStateAction<string>>;
 };
 
 export default function MatchGameModal(props: modalProps) {
   const [option, setOption] = useState("");
+  const [notice, setNotice] = useState("");
   const socket = getSocket();
   const navigate = useNavigate();
 
   function setStatusHandler(e: React.ChangeEvent<HTMLSelectElement>) {
     setOption(e.target.value);
-    if (props.notice) props.setNotice("");
+    if (notice) setNotice("");
   }
 
   const listener = (res: any) => {
     console.log(res);
-    props.setNotice("");
+    setNotice("");
     if (res.status === "match") {
       navigate(`/game/${res.roomId}`);
     } else if (res.status === "searching") {
-      props.setNotice("게임 찾는 중...");
+      setNotice("게임 찾는 중...");
     } else if (res.status === "error") {
       alert(res.detail);
     }
@@ -45,7 +44,7 @@ export default function MatchGameModal(props: modalProps) {
         rule: option,
       });
     } else {
-      props.setNotice("옵션을 선택해주세요.");
+      setNotice("옵션을 선택해주세요.");
     }
   }
 
@@ -61,7 +60,7 @@ export default function MatchGameModal(props: modalProps) {
             <option value="arcade">특별 게임</option>
           </select>
         </S.Wrapper>
-        <S.Span color="red">{props.notice}</S.Span>
+        <S.Span color="red">{notice}</S.Span>
         <S.Wrapper>
           <S.ModalButton2 type="submit">확인</S.ModalButton2>
           <S.ModalButton2 type="button" onClick={props.close}>

--- a/src/modal/MatchGameModal.tsx
+++ b/src/modal/MatchGameModal.tsx
@@ -64,9 +64,13 @@ export default function MatchGameModal(props: modalProps) {
 
   function cancelHandler() {
     console.log(option)
-    socket.emit("cancleSearch", {
-      rule: option,
-    })
+    if (status) {
+      socket.emit("cancleSearch", {
+        rule: option,
+      })
+    } else {
+      props.close();
+    }
   }
 
   return (

--- a/src/modal/MatchGameModal.tsx
+++ b/src/modal/MatchGameModal.tsx
@@ -10,6 +10,7 @@ type modalProps = {
 export default function MatchGameModal(props: modalProps) {
   const [option, setOption] = useState("");
   const [notice, setNotice] = useState("");
+  const [status, setStatus] = useState("");
   const socket = getSocket();
   const navigate = useNavigate();
 
@@ -20,20 +21,31 @@ export default function MatchGameModal(props: modalProps) {
 
   const listener = (res: any) => {
     console.log(res);
-    setNotice("");
+    setStatus(res.status);
     if (res.status === "match") {
       navigate(`/game/${res.roomId}`);
     } else if (res.status === "searching") {
       setNotice("게임 찾는 중...");
     } else if (res.status === "error") {
       alert(res.detail);
+    } else {
+      console.log(res);
+    }
+  };
+
+  const cancelListener = (res: any) => {
+    console.log(res);
+    if (res.status === "approved") {
+      props.close();
     }
   };
 
   useEffect(() => {
     socket.on("searchGameResult", listener);
+    socket.on("cancleSearchResult", cancelListener);
     return () => {
       socket.off("searchGameResult", listener);
+      socket.off("cancleSearchResult", cancelListener);
     };
   });
 
@@ -46,6 +58,13 @@ export default function MatchGameModal(props: modalProps) {
     } else {
       setNotice("옵션을 선택해주세요.");
     }
+  }
+
+  function cancelHandler() {
+    console.log(option)
+    socket.emit("cancleSearch", {
+      rule: option,
+    })
   }
 
   return (
@@ -62,8 +81,8 @@ export default function MatchGameModal(props: modalProps) {
         </S.Wrapper>
         <S.Span color="red">{notice}</S.Span>
         <S.Wrapper>
-          <S.ModalButton2 type="submit">확인</S.ModalButton2>
-          <S.ModalButton2 type="button" onClick={props.close}>
+          <S.ModalButton2 type="submit" disabled={status === "searching"}>확인</S.ModalButton2>
+          <S.ModalButton2 type="button" onClick={cancelHandler}>
             취소
           </S.ModalButton2>
         </S.Wrapper>

--- a/src/modal/MatchGameModal.tsx
+++ b/src/modal/MatchGameModal.tsx
@@ -72,7 +72,7 @@ export default function MatchGameModal(props: modalProps) {
       <h2>게임 매치 등록하기</h2>
       <form onSubmit={setHandler}>
         <S.Wrapper>
-          <select onChange={setStatusHandler}>
+          <select onChange={setStatusHandler} disabled={status === "searching"}>
             <option value="opt">-- 옵션을 선택해주세요 --</option>
             <option value="normal">일반 게임</option>
             <option value="rank">랭크 게임</option>

--- a/src/modal/MatchGameModal.tsx
+++ b/src/modal/MatchGameModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import * as S from "./layout/style";
 import { useNavigate } from "react-router-dom";
 import { getSocket } from "socket/socket";
+import LoadingCircle from "components/LoadingCircle";
 
 type modalProps = {
   close: () => void;
@@ -51,6 +52,7 @@ export default function MatchGameModal(props: modalProps) {
 
   function setHandler(e: React.MouseEvent<HTMLFormElement>) {
     e.preventDefault();
+    setStatus("searching");
     if (option) {
       socket.emit("searchGame", {
         rule: option,
@@ -79,7 +81,10 @@ export default function MatchGameModal(props: modalProps) {
             <option value="arcade">특별 게임</option>
           </select>
         </S.Wrapper>
-        <S.Span color="red">{notice}</S.Span>
+        <S.Wrapper>
+          <S.Span2 color="red">{notice}</S.Span2>
+          {notice && status === "searching" && <LoadingCircle w={30} h={30} />}
+        </S.Wrapper>
         <S.Wrapper>
           <S.ModalButton2 type="submit" disabled={status === "searching"}>확인</S.ModalButton2>
           <S.ModalButton2 type="button" onClick={cancelHandler}>

--- a/src/modal/MatchGameModal.tsx
+++ b/src/modal/MatchGameModal.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import * as S from "./layout/style";
 import { useNavigate } from "react-router-dom";
 import { getSocket } from "socket/socket";

--- a/src/modal/NotificationModal.tsx
+++ b/src/modal/NotificationModal.tsx
@@ -1,7 +1,9 @@
 import { useNavigate } from "react-router-dom";
 import { NotiType } from "hooks/useNotiModal";
 import * as S from "./layout/style";
-import { getSocket } from "socket/socket";
+import useGameModal from "hooks/useGameModal";
+import AcceptGameModal from "./AcceptGameModal";
+import { useState } from "react";
 
 type modalProps = {
   close: () => void;
@@ -10,14 +12,21 @@ type modalProps = {
 
 function NotificationModal(props: modalProps) {
   const navigate = useNavigate();
-  const socket = getSocket();
-  const joinHandler = (e: React.MouseEvent<HTMLSpanElement>) => {
+  const [from, setFrom] = useState("");
+  const G = useGameModal();
+
+  const chatJoinHandler = (e: React.MouseEvent<HTMLSpanElement>) => {
     const target = e.currentTarget.id.split("-");
     navigate({
       pathname: `/chat/${target[0]}`,
       search: `title=${target[1]}`,
     });
     props.close();
+  };
+
+  const gameJoinHandler = (e: React.MouseEvent<HTMLSpanElement>) => {
+    setFrom(e.currentTarget.id);
+    G.onOpen();
   };
 
   return (
@@ -27,15 +36,22 @@ function NotificationModal(props: modalProps) {
         {props.notiList.length > 0 ? (
           props.notiList.map((noti) => {
             return (
-              <div key={noti.chatId}>
-                <S.Span
-                  onClick={joinHandler}
-                  id={`${noti.chatId}-${noti.chatTitle}`}
-                >
-                  {noti.title}
-                </S.Span>
-                <br />
-              </div>
+              <>
+                {noti.type === "chat" ? (
+                  <div key={noti.chatId}>
+                    <S.Span onClick={chatJoinHandler} id={`${noti.chatId}-${noti.chatTitle}`}>
+                      {noti.title}
+                    </S.Span>
+                    <br />
+                  </div>
+                ) : (
+                  <div key={`${Date.now()}_${noti.from}`}>
+                    <S.Span onClick={gameJoinHandler} id={`${noti.from}`}>
+                      {noti.title}
+                    </S.Span>
+                  </div>
+                )}
+              </>
             );
           })
         ) : (
@@ -45,6 +61,13 @@ function NotificationModal(props: modalProps) {
       <S.BtnWrapper>
         <S.ModalButton2 onClick={props.close}>확인</S.ModalButton2>
       </S.BtnWrapper>
+      {
+        G.isOpen && (
+          <G.GameModal back="noBack">
+            <AcceptGameModal close={G.onClose} targetUser={from} parentClose={props.close} />
+          </G.GameModal>
+        )
+      }
     </S.NotificationLayout>
   );
 }

--- a/src/modal/layout/Modal.tsx
+++ b/src/modal/layout/Modal.tsx
@@ -1,20 +1,22 @@
 import { createPortal } from "react-dom";
-import * as S from "./style"
+import * as S from "./style";
 
 type modalProps = {
-  children: React.ReactElement
+  children: React.ReactElement;
   setView: (e: React.MouseEvent<HTMLDivElement>) => void;
   set?: string;
-}
+  back?: string;
+};
 
 export default function Modal(props: modalProps) {
   const modalRoot = document.getElementById("modal-root");
   return createPortal(
     <>
-      <S.Backdrop onClick={props.setView} />
+      <S.Backdrop onClick={props.setView} id={props.back} />
       <S.Modal id={props.set} open>
         {props.children}
       </S.Modal>
-    </>, modalRoot as Element
-  )
+    </>,
+    modalRoot as Element,
+  );
 }

--- a/src/modal/layout/Modal.tsx
+++ b/src/modal/layout/Modal.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom";
 import * as S from "./style"
 
 type modalProps = {
@@ -7,12 +8,13 @@ type modalProps = {
 }
 
 export default function Modal(props: modalProps) {
-  return (
+  const modalRoot = document.getElementById("modal-root");
+  return createPortal(
     <>
-      <S.Backdrop onClick={props.setView}/>
+      <S.Backdrop onClick={props.setView} />
       <S.Modal id={props.set} open>
         {props.children}
       </S.Modal>
-    </>
+    </>, modalRoot as Element
   )
 }

--- a/src/modal/layout/style.tsx
+++ b/src/modal/layout/style.tsx
@@ -25,7 +25,7 @@ export const Backdrop = styled.div`
   left: 0;
   width: 100%;
   height: 100vh;
-  background-color: rgba(0, 0, 0, 0.4);
+  ${(props) => (props.id !== "noBack" ? "background-color: rgba(0, 0, 0, 0.4);" : "")}
   z-index: 1;
 `;
 
@@ -294,7 +294,7 @@ export const SettingPwLayout = styled.div`
   background: white;
   font-size: 12px;
   border-radius: 20px;
-`
+`;
 
 /* 
   match game
@@ -307,4 +307,22 @@ export const MatchGameLayout = styled.div`
   background: white;
   font-size: 12px;
   border-radius: 20px;
-`
+`;
+
+/* 
+  accept game
+*/
+
+export const AcceptGameLayout = styled.div`
+  position: relative;
+  width: 100%;
+  height: 180px;
+  background: white;
+  font-size: 12px;
+  border-radius: 20px;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+`;
+

--- a/src/modal/layout/style.tsx
+++ b/src/modal/layout/style.tsx
@@ -53,10 +53,17 @@ export const Button = styled.button`
   border: 1px solid lightgray;
   line-height: 1.5;
 `;
+
 export const Span = styled.span`
   font-size: 11px;
   color: ${(props) => props.color};
   cursor: pointer;
+`;
+
+export const Span2 = styled.span`
+  font-size: 11px;
+  color: ${(props) => props.color};
+  position: absolute;
 `;
 
 export const ModalButton2 = styled(Button)`
@@ -130,6 +137,7 @@ export const Wrapper = styled.div`
   margin: 5% 0;
   display: flex;
   justify-content: space-around;
+  align-items: center;
 `;
 
 /*

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -69,9 +69,15 @@ function Auth() {
     socket.emit("subscribe", {
       type: "chatInvitation",
     });
+    socket.emit("subscribe", {
+      type: "gameInvitation",
+    });
     return () => {
       socket.emit("unsubscribe", {
         type: "chatInvitation",
+      });
+      socket.emit("unsubscribe", {
+        type: "gameInvitation",
       });
     };
   }, []);

--- a/src/pages/auth/game/list/GameList.tsx
+++ b/src/pages/auth/game/list/GameList.tsx
@@ -3,15 +3,13 @@ import { isAuth } from "userAuth";
 import GameItem from "./GameItem";
 import * as S from "./style";
 import RightSide from "@rightSide/RightSide";
-import { useState } from "react";
-import Modal from "modal/layout/Modal";
 import MatchGameModal from "modal/MatchGameModal";
+import useGameModal from "hooks/useGameModal";
 
 export default function GameList() {
   const navigate = useNavigate();
   if (!isAuth()) navigate("/");
-  const [showModal, setShowModal] = useState(false);
-  const [notice, setNotice] = useState("");
+  const G = useGameModal();
 
   let gameCnt = 0;
   // 임시 더미데이터
@@ -32,25 +30,17 @@ export default function GameList() {
     },
   ];
 
-  const openModalHandler = () => {
-    setShowModal(true);
-  };
-
-  const closeModalHandler = () => {
-    setShowModal(false);
-  };
-
   return (
     <>
       <S.PageLayout>
-        {showModal && (
-          <Modal setView={closeModalHandler}>
-            <MatchGameModal close={closeModalHandler} notice={notice} setNotice={setNotice} />
-          </Modal>
+        {G.isOpen && (
+          <G.GameModal>
+            <MatchGameModal close={G.onClose} />
+          </G.GameModal>
         )}
         <S.HeaderBox>
           <S.H2>진행중인 게임</S.H2>
-          <S.MatchMakingBtn onClick={openModalHandler}>매치메이킹 등록</S.MatchMakingBtn>
+          <S.MatchMakingBtn onClick={G.onOpen}>매치메이킹 등록</S.MatchMakingBtn>
         </S.HeaderBox>
         <S.GameList>
           <S.GameItem head>

--- a/src/pages/auth/game/room/GameRoom.tsx
+++ b/src/pages/auth/game/room/GameRoom.tsx
@@ -13,30 +13,39 @@ export default function GameRoom() {
   if (Number.isNaN(Number(gameId))) navigate("/404");
   const socket = getSocket();
   const roomId = Number(gameId);
+  const [result, setResult] = useState("");
 
   const listener = (res: { type: string; status: any }) => {
-    console.log(res);
+    if (res.status === "approved") {
+      navigate("/game/list");
+    } else {
+      console.log(res);
+    }
   };
 
   useEffect(() => {
     socket.on("exitGameRoomResult", listener);
     socket.emit("subscribe", {
       type: "gameRoom",
-      roomId: roomId
+      roomId: roomId,
     });
     return () => {
       socket.off("exitGameRoomResult", listener);
       socket.emit("unsubscribe", {
         type: "gameRoom",
-        roomId: roomId
+        roomId: roomId,
       });
     };
   }, [roomId]);
 
   const exitGameHandler = () => {
-    socket.emit("exitGameRoom", {
-      roomId: roomId,
-    });
+    if (result) {
+      navigate("/game/list");
+    } else {
+      socket.emit("exitGameRoom", {
+        roomId: roomId,
+      });
+    }
   };
 
   return (
@@ -44,9 +53,9 @@ export default function GameRoom() {
       <S.PageLayout>
         <S.HeaderBox>
           <S.H2>{gameId}번 게임방 접속 완료</S.H2>
+          <button onClick={exitGameHandler}>나가기</button>
         </S.HeaderBox>
-        <button onClick={exitGameHandler}>나가기</button>
-        <Screen />
+        <Screen result={result} setResult={setResult} />
       </S.PageLayout>
       <RightSide />
     </>

--- a/src/pages/auth/game/room/GameRoom.tsx
+++ b/src/pages/auth/game/room/GameRoom.tsx
@@ -3,7 +3,7 @@ import { isAuth } from "userAuth";
 import * as S from "./style";
 import RightSide from "@rightSide/RightSide";
 import { getSocket } from "socket/socket";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import Screen from "./Screen";
 
 export default function GameRoom() {

--- a/src/pages/auth/game/room/Screen.tsx
+++ b/src/pages/auth/game/room/Screen.tsx
@@ -1,10 +1,15 @@
-import { useEffect, useRef, useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import { getSocket } from "socket/socket";
 import { getUsername } from "userAuth";
 import * as S from "./style";
 
-export default function Screen() {
+type PropsType = {
+  result: string;
+  setResult: Dispatch<SetStateAction<string>>;
+}
+
+export default function Screen(props: PropsType) {
   const { gameId } = useParams();
   const socket = getSocket();
   const username = getUsername();
@@ -21,7 +26,6 @@ export default function Screen() {
   const [blueX, setBlueX] = useState(0);
   const [redX, setRedX] = useState(0);
   const [camp, setCamp] = useState("");
-  const [result, setResult] = useState("");
   const [score, setScore] = useState<{ blue: number; red: number }>({ blue: 0, red: 0 });
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const canvas = canvasRef.current;
@@ -55,13 +59,13 @@ export default function Screen() {
     } else if (res.type === "win") {
       if (res.roomId !== Number(gameId)) return;
       if (score.blue === 5 || score.red === 5) {
-        setResult("승리");
+        props.setResult("승리");
       } else {
-        setResult("상대방이 나갔습니다")
+        props.setResult("상대방이 나갔습니다")
       }
     } else if (res.type === "lose") {
       if (res.roomId !== Number(gameId)) return;
-      setResult("패배");
+      props.setResult("패배");
     } else {
       console.log(res);
     }
@@ -126,12 +130,12 @@ export default function Screen() {
   }
 
   function drawResult() {
-    if (ctx && canvas && result) {
+    if (ctx && canvas && props.result) {
       ctx.font = "35px Arial";
       ctx.textAlign = "center";
-      if (result === "승리") ctx.fillStyle = "#0095DD";
-      else if (result === "패배") ctx.fillStyle = "#FF0088";
-      ctx.fillText(result, canvas.width / 2, canvas.height / 3);
+      if (props.result === "승리") ctx.fillStyle = "#0095DD";
+      else if (props.result === "패배") ctx.fillStyle = "#FF0088";
+      ctx.fillText(props.result, canvas.width / 2, canvas.height / 3);
     }
   }
 
@@ -153,7 +157,7 @@ export default function Screen() {
       drawScore();
       drawResult();
     }
-  }, [ballX, ballY, redY, blueY, result]);
+  }, [ballX, ballY, redY, blueY, props.result]);
 
   return <S.Canvas ref={canvasRef} width={540} height={360}></S.Canvas>;
 }

--- a/src/pages/auth/game/room/Screen.tsx
+++ b/src/pages/auth/game/room/Screen.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { getSocket } from "socket/socket";
 import { getUsername } from "userAuth";
 import * as S from "./style";
+import { useQueryClient } from "@tanstack/react-query";
 
 type PropsType = {
   result: string;
@@ -30,6 +31,7 @@ export default function Screen(props: PropsType) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const canvas = canvasRef.current;
   const ctx = canvas?.getContext("2d");
+  const queryClient = useQueryClient();
 
   const listener = (res: { type: string; roomId?: number; status: any }) => {
     if (res.type === "game") {
@@ -58,14 +60,18 @@ export default function Screen(props: PropsType) {
       }
     } else if (res.type === "win") {
       if (res.roomId !== Number(gameId)) return;
-      if (score.blue === 5 || score.red === 5) {
-        props.setResult("승리");
-      } else {
+      if (score.blue === 5) {
+        props.setResult("blue 승리");
+      } else if (score.red === 5) {
+        props.setResult("red 승리");
+      }else {
         props.setResult("상대방이 나갔습니다")
       }
+      queryClient.invalidateQueries(["profile"]);
     } else if (res.type === "lose") {
       if (res.roomId !== Number(gameId)) return;
       props.setResult("패배");
+      queryClient.invalidateQueries(["profile"]);
     } else {
       console.log(res);
     }
@@ -131,9 +137,10 @@ export default function Screen(props: PropsType) {
 
   function drawResult() {
     if (ctx && canvas && props.result) {
+      const result = props.result.split(" ")[1];
       ctx.font = "35px Arial";
       ctx.textAlign = "center";
-      if (props.result === "승리") ctx.fillStyle = "#0095DD";
+      if (result === "승리") ctx.fillStyle = "#0095DD";
       else if (props.result === "패배") ctx.fillStyle = "#FF0088";
       ctx.fillText(props.result, canvas.width / 2, canvas.height / 3);
     }


### PR DESCRIPTION
## 개요
- 게임 화면 스코어 및 결과 표시, 게임 신청 

## 작업사항
- 게임 화면 스코어 및 결과
- 게임 나가기
- 게임 신청 모달
- 게임 신청시 알림
- 게임 신청 수락/거절 모달
- 게임 찾기 취소
- etc. 유저 상태(온라인, 오프라인 게임중) 수정, 연속 emit 방지 

## 변경로직
- userInfo에 gameInvitationModal 추가, userDropMenu에 onInviteGameOpen추가, rightSideType 추가
- useNotiModal에 gameInvitation 이벤트 추가, notificationModal에 AcceptModal 추가

## 코멘트
확인되는 에러는 다음 작업에 할게요~
<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
