### PR TITLE
feat: 프로필 업적배지 추가 및 히스토리 업데이트 #109

### DIFF
--- a/src/@types/profile-types/profileTypes.d.ts
+++ b/src/@types/profile-types/profileTypes.d.ts
@@ -6,6 +6,7 @@ declare module "profile-types" {
       win: number;
       lose: number;
       relation: "myself" | "friend" | "others";
+      achievement: string[];
       gameHistory: [
         {
           uniqueId: number;

--- a/src/@types/profile-types/profileTypes.d.ts
+++ b/src/@types/profile-types/profileTypes.d.ts
@@ -22,4 +22,14 @@ declare module "profile-types" {
   };
 
   export type QuerySet = [QueryKey, string | undefined][];
+
+  export type AchivementProps = {
+    achivements?: string[];
+    username?: string;
+  };
+
+  export type BadgeProps = {
+    achivement: string;
+    username?: string;
+  };
 }

--- a/src/@types/profile-types/profileTypes.d.ts
+++ b/src/@types/profile-types/profileTypes.d.ts
@@ -1,0 +1,24 @@
+declare module "profile-types" {
+  export type UserProfileProps = {
+    user?: {
+      username: string;
+      rating: number;
+      win: number;
+      lose: number;
+      relation: "myself" | "friend" | "others";
+      gameHistory: [
+        {
+          uniqueId: number;
+          red: string;
+          blue: string;
+          redScore: number;
+          blueScore: number;
+          winner: string;
+          type: string;
+        },
+      ];
+    };
+  };
+
+  export type QuerySet = [QueryKey, string | undefined][];
+}

--- a/src/@types/profile-types/profileTypes.d.ts
+++ b/src/@types/profile-types/profileTypes.d.ts
@@ -9,13 +9,13 @@ declare module "profile-types" {
       achievement: string[];
       gameHistory: [
         {
-          uniqueId: number;
+          id: number;
+          rule: "normal" | "rank" | "arcade";
           red: string;
           blue: string;
           redScore: number;
           blueScore: number;
           winner: string;
-          type: string;
         },
       ];
     };

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -59,3 +59,17 @@ export async function postAvatar(form: FormData) {
     }
   }
 }
+
+export async function getBadge(win: string) {
+  try {
+    const res = await axios.get(`/user/badge/${win}`, {
+      responseType: "blob",
+    });
+    return URL.createObjectURL(res.data);
+  } catch (err: unknown) {
+    if (err instanceof AxiosError && err.response) {
+      console.error(err.response);
+      return err.response;
+    }
+  }
+}

--- a/src/components/leftSide/AchievementBadge.tsx
+++ b/src/components/leftSide/AchievementBadge.tsx
@@ -1,16 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
+import { getBadge } from "api/user";
+import { AchivementProps, BadgeProps } from "profile-types";
 import * as S from "./style";
 
-type AchivementProp = {
-  achivements?: string[];
-};
+function BadgeSet({ achivement, username }: BadgeProps) {
+  const BadgeQuery = useQuery({
+    queryKey: ["badge", `${achivement}`, `${username}`],
+    queryFn: () => {
+      return getBadge(`${achivement}`);
+    },
+  });
 
-export default function AchievementBadge({ achivements }: AchivementProp) {
+  return (
+    <S.BadgeSet>
+      <S.BadgeImg src={BadgeQuery?.data as string} alt={`${achivement}배지`} />
+      <span>{achivement}</span>
+    </S.BadgeSet>
+  );
+}
+
+export default function AchievementBadge({ achivements, username }: AchivementProps) {
   return (
     <>
       <S.InfoLabel>업적</S.InfoLabel>
-      {achivements?.map((achive) => {
-        return <S.InfoValue key={achive}>{achive}</S.InfoValue>;
-      })}
+      <S.BadgeBox>
+        {achivements?.map((achivement) => {
+          return <BadgeSet key={achivement} achivement={achivement} username={username} />;
+        })}
+      </S.BadgeBox>
     </>
   );
 }

--- a/src/components/leftSide/AchievementBadge.tsx
+++ b/src/components/leftSide/AchievementBadge.tsx
@@ -1,0 +1,16 @@
+import * as S from "./style";
+
+type AchivementProp = {
+  achivements?: string[];
+};
+
+export default function AchievementBadge({ achivements }: AchivementProp) {
+  return (
+    <>
+      <S.InfoLabel>업적</S.InfoLabel>
+      {achivements?.map((achive) => {
+        return <S.InfoValue key={achive}>{achive}</S.InfoValue>;
+      })}
+    </>
+  );
+}

--- a/src/components/leftSide/AchievementBadge.tsx
+++ b/src/components/leftSide/AchievementBadge.tsx
@@ -21,13 +21,13 @@ function BadgeSet({ achivement, username }: BadgeProps) {
 
 export default function AchievementBadge({ achivements, username }: AchivementProps) {
   return (
-    <>
+    <S.InfoWrapper>
       <S.InfoLabel>업적</S.InfoLabel>
       <S.BadgeBox>
         {achivements?.map((achivement) => {
           return <BadgeSet key={achivement} achivement={achivement} username={username} />;
         })}
       </S.BadgeBox>
-    </>
+    </S.InfoWrapper>
   );
 }

--- a/src/components/leftSide/LogoutBtn.tsx
+++ b/src/components/leftSide/LogoutBtn.tsx
@@ -1,0 +1,30 @@
+import { useContext } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { AuthContext } from "hooks/context/AuthContext";
+import { distroyAuth } from "userAuth";
+import { disconnectSocket } from "socket/socket";
+import { QuerySet } from "profile-types";
+import { Button } from "./style";
+
+export default function LogoutBtn() {
+  const setSigned = useContext(AuthContext);
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  function onLogout() {
+    distroyAuth();
+    disconnectSocket();
+    if (setSigned) setSigned(false);
+    const querySet = queryClient.getQueriesData(["avatar"]);
+    (querySet as QuerySet).map((queryData) => {
+      if (queryData[1]) return URL.revokeObjectURL(queryData[1]);
+    });
+    queryClient.resetQueries(["profile"]);
+    queryClient.resetQueries(["avatar"]);
+    queryClient.resetQueries(["list"]);
+    navigate("/");
+  }
+
+  return <Button onClick={onLogout}>로그아웃</Button>;
+}

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -1,23 +1,18 @@
-import { useContext, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { getAvatar } from "api/user";
-import { distroyAuth, getUsername } from "userAuth";
-import { AuthContext } from "hooks/context/AuthContext";
-import { disconnectSocket } from "socket/socket";
+import { getUsername } from "userAuth";
 import Modal from "modal/layout/Modal";
 import AvatarUploadModal from "modal/AvatarUploadModal";
 import AddFriendBtn from "./AddFriendBtn";
 import RemoveFrendBtn from "./RemoveFriendBtn";
-import { QuerySet, UserProfileProps } from "profile-types";
+import LogoutBtn from "./LogoutBtn";
+import { UserProfileProps } from "profile-types";
 import * as S from "./style";
 
 export function ProfileData({ user }: UserProfileProps) {
-  const setSigned = useContext(AuthContext);
-  const navigate = useNavigate();
   const [showModal, setShowModal] = useState(false);
   const myProfile = getUsername() === user?.username;
-  const queryClient = useQueryClient();
 
   const avatarQuery = useQuery({
     queryKey: ["avatar", `${user?.username}`],
@@ -34,20 +29,6 @@ export function ProfileData({ user }: UserProfileProps) {
   const closeModalHandler = () => {
     setShowModal(false);
   };
-
-  function onLogout() {
-    distroyAuth();
-    disconnectSocket();
-    if (setSigned) setSigned(false);
-    const querySet = queryClient.getQueriesData(["avatar"]);
-    (querySet as QuerySet).map((queryData) => {
-      if (queryData[1]) return URL.revokeObjectURL(queryData[1]);
-    });
-    queryClient.resetQueries(["profile"]);
-    queryClient.resetQueries(["avatar"]);
-    queryClient.resetQueries(["list"]);
-    navigate("/");
-  }
 
   return (
     <S.ProfileLayout>
@@ -108,7 +89,7 @@ export function ProfileData({ user }: UserProfileProps) {
           })}
       </S.HistoryList>
       <S.ButtonBox>
-        {(!user || user.relation === "myself") && <S.Button onClick={onLogout}>로그아웃</S.Button>}
+        {(!user || user.relation === "myself") && <LogoutBtn />}
         {user && user?.relation === "friend" && <RemoveFrendBtn username={user.username} />}
         {user && user.relation === "others" && <AddFriendBtn username={user.username} />}
       </S.ButtonBox>

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -67,7 +67,7 @@ export function ProfileData({ user }: UserProfileProps) {
       <AchievementBadge achivements={user?.achievement} username={user?.username} />
       <S.InfoLabel>히스토리</S.InfoLabel>
       <S.HistoryList>
-        {user?.gameHistory.map((game) => {
+        {user?.gameHistory.reverse().map((game) => {
           return (
             <S.HistoryItem key={game.id}>
               <S.Rule>

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -71,24 +71,29 @@ export function ProfileData({ user }: UserProfileProps) {
       <AchievementBadge achivements={user?.achievement} username={user?.username} />
       <S.InfoLabel>히스토리</S.InfoLabel>
       <S.HistoryList>
-        {user &&
-          user?.gameHistory.map((game) => {
-            return (
-              <S.HistoryItem key={game.id}>
-                <S.Score>
-                  {game.rule === "rank" ? "경쟁" : game.rule === "normal" ? "일반" : "아케이드"}전
+        {user?.gameHistory.map((game) => {
+          return (
+            <S.HistoryItem key={game.id}>
+              <S.Rule>
+                🚩 {game.rule === "rank" ? "경쟁" : game.rule === "normal" ? "일반" : "아케이드"}전
+              </S.Rule>
+              <S.Players>
+                <S.Player winner={game.winner === "red"}>{game.red}</S.Player>
+                <S.Versus>vs</S.Versus>
+                <S.Player winner={game.winner === "blue"}>{game.blue}</S.Player>
+              </S.Players>
+              <S.ScoreBox>
+                <S.Score red winner={game.winner === "red"}>
+                  {game.redScore}
                 </S.Score>
-                <S.Players>
-                  <S.Player>{game.red}</S.Player>
-                  <S.Versus>vs</S.Versus>
-                  <S.Player>{game.blue}</S.Player>
-                </S.Players>
-                <S.Score>
-                  {game.redScore} : {game.blueScore}
+                <S.Versus>:</S.Versus>
+                <S.Score blue winner={game.winner === "blue"}>
+                  {game.blueScore}
                 </S.Score>
-              </S.HistoryItem>
-            );
-          })}
+              </S.ScoreBox>
+            </S.HistoryItem>
+          );
+        })}
       </S.HistoryList>
       <S.ButtonBox>
         {(!user || user.relation === "myself") && <LogoutBtn />}

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -68,7 +68,7 @@ export function ProfileData({ user }: UserProfileProps) {
           {user && `${user.win}승 ${user.lose}패`}
         </S.InfoValue>
       </S.InfoWrapper>
-      <AchievementBadge achivements={user?.achievement} />
+      <AchievementBadge achivements={user?.achievement} username={user?.username} />
       <S.InfoLabel>히스토리</S.InfoLabel>
       <S.HistoryList>
         {user &&

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -8,6 +8,7 @@ import AddFriendBtn from "./buttons/AddFriendBtn";
 import RemoveFrendBtn from "./buttons/RemoveFriendBtn";
 import LogoutBtn from "./buttons/LogoutBtn";
 import { UserProfileProps } from "profile-types";
+import AchievementBadge from "./AchievementBadge";
 import * as S from "./style";
 
 export function ProfileData({ user }: UserProfileProps) {
@@ -67,6 +68,7 @@ export function ProfileData({ user }: UserProfileProps) {
           {user && `${user.win}승 ${user.lose}패`}
         </S.InfoValue>
       </S.InfoWrapper>
+      <AchievementBadge achivements={user?.achievement} />
       <S.InfoLabel>히스토리</S.InfoLabel>
       <S.HistoryList>
         {user &&

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -74,9 +74,9 @@ export function ProfileData({ user }: UserProfileProps) {
         {user &&
           user?.gameHistory.map((game) => {
             return (
-              <S.HistoryItem key={game.uniqueId}>
+              <S.HistoryItem key={game.id}>
                 <S.Score>
-                  {game.type === "rank" ? "경쟁" : game.type === "normal" ? "일반" : "아케이드"}전
+                  {game.rule === "rank" ? "경쟁" : game.rule === "normal" ? "일반" : "아케이드"}전
                 </S.Score>
                 <S.Players>
                   <S.Player>{game.red}</S.Player>

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -4,9 +4,9 @@ import { getAvatar } from "api/user";
 import { getUsername } from "userAuth";
 import Modal from "modal/layout/Modal";
 import AvatarUploadModal from "modal/AvatarUploadModal";
-import AddFriendBtn from "./AddFriendBtn";
-import RemoveFrendBtn from "./RemoveFriendBtn";
-import LogoutBtn from "./LogoutBtn";
+import AddFriendBtn from "./buttons/AddFriendBtn";
+import RemoveFrendBtn from "./buttons/RemoveFriendBtn";
+import LogoutBtn from "./buttons/LogoutBtn";
 import { UserProfileProps } from "profile-types";
 import * as S from "./style";
 

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -53,20 +53,16 @@ export function ProfileData({ user }: UserProfileProps) {
         />
       )}
       <S.InfoWrapper>
-        <S.InfoLabel>
-          닉네임
-          <br />
-          레이팅
-          <br />
-          전적
-        </S.InfoLabel>
-        <S.InfoValue>
-          {user && user.username}
-          <br />
-          {user && user.rating}
-          <br />
-          {user && `${user.win}승 ${user.lose}패`}
-        </S.InfoValue>
+        <S.InfoLabel>닉네임</S.InfoLabel>
+        <S.InfoValue>{user && user.username}</S.InfoValue>
+      </S.InfoWrapper>
+      <S.InfoWrapper>
+        <S.InfoLabel>레이팅</S.InfoLabel>
+        <S.InfoValue>{user && user.rating}</S.InfoValue>
+      </S.InfoWrapper>
+      <S.InfoWrapper>
+        <S.InfoLabel>전적</S.InfoLabel>
+        <S.InfoValue>{user && `${user.win}승 ${user.lose}패`}</S.InfoValue>
       </S.InfoWrapper>
       <AchievementBadge achivements={user?.achievement} username={user?.username} />
       <S.InfoLabel>히스토리</S.InfoLabel>

--- a/src/components/leftSide/buttons/AddFriendBtn.tsx
+++ b/src/components/leftSide/buttons/AddFriendBtn.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import * as S from "./style";
+import * as S from "../style";
 import { getSocket } from "socket/socket";
 import { ChatRoomResponse } from "socket/active/chatEventType";
 import { useQueryClient } from "@tanstack/react-query";
@@ -31,6 +31,6 @@ export default function AddFriendBtn(props: { username: string }) {
       username: props.username,
     });
   };
-  
+
   return <S.Button onClick={addBtnHandler}>친구 추가</S.Button>;
 }

--- a/src/components/leftSide/buttons/LogoutBtn.tsx
+++ b/src/components/leftSide/buttons/LogoutBtn.tsx
@@ -5,7 +5,7 @@ import { AuthContext } from "hooks/context/AuthContext";
 import { distroyAuth } from "userAuth";
 import { disconnectSocket } from "socket/socket";
 import { QuerySet } from "profile-types";
-import { Button } from "./style";
+import { Button } from "../style";
 
 export default function LogoutBtn() {
   const setSigned = useContext(AuthContext);

--- a/src/components/leftSide/buttons/LogoutBtn.tsx
+++ b/src/components/leftSide/buttons/LogoutBtn.tsx
@@ -27,6 +27,7 @@ export default function LogoutBtn() {
     queryClient.resetQueries(["profile"]);
     queryClient.resetQueries(["avatar"]);
     queryClient.resetQueries(["list"]);
+    queryClient.resetQueries(["badge"]);
     navigate("/");
   }
 

--- a/src/components/leftSide/buttons/LogoutBtn.tsx
+++ b/src/components/leftSide/buttons/LogoutBtn.tsx
@@ -16,8 +16,12 @@ export default function LogoutBtn() {
     distroyAuth();
     disconnectSocket();
     if (setSigned) setSigned(false);
-    const querySet = queryClient.getQueriesData(["avatar"]);
-    (querySet as QuerySet).map((queryData) => {
+    const avartarSet = queryClient.getQueriesData(["avatar"]);
+    (avartarSet as QuerySet).map((queryData) => {
+      if (queryData[1]) return URL.revokeObjectURL(queryData[1]);
+    });
+    const badgeSet = queryClient.getQueriesData(["badge"]);
+    (badgeSet as QuerySet).map((queryData) => {
       if (queryData[1]) return URL.revokeObjectURL(queryData[1]);
     });
     queryClient.resetQueries(["profile"]);

--- a/src/components/leftSide/buttons/RemoveFriendBtn.tsx
+++ b/src/components/leftSide/buttons/RemoveFriendBtn.tsx
@@ -1,5 +1,5 @@
 import { getSocket } from "socket/socket";
-import * as S from "./style";
+import * as S from "../style";
 import { useQueryClient } from "@tanstack/react-query";
 import { ChatRoomResponse } from "socket/active/chatEventType";
 import { useEffect } from "react";

--- a/src/components/leftSide/style.tsx
+++ b/src/components/leftSide/style.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { darkGray } from "style/color";
+import { darkGray, lightBlue, lightRed } from "style/color";
 import * as font from "style/font";
 import * as button from "style/button";
 
@@ -87,12 +87,35 @@ export const BadgeImg = styled.img`
 export const HistoryList = styled.ul`
   /* max-height: 300px; */
   /* flex: 1 0 auto; */
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
   overflow: auto;
+  padding: 0;
 `;
 
 export const HistoryItem = styled.li`
   display: flex;
   flex-direction: column;
+  ${font.footer}
+  line-height: 1.5;
+
+  border: 1px solid;
+  margin: 8px 5% 0;
+  padding: 10px 0 5px;
+  position: relative;
+`;
+
+export const Rule = styled.span`
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  transform: translate(-50%, 0);
+  white-space: nowrap;
+
+  background-color: white;
+  padding: 0 5px;
 `;
 
 export const Players = styled.div`
@@ -100,18 +123,35 @@ export const Players = styled.div`
   justify-content: center;
 `;
 
-export const Player = styled.span`
-  width: 40;
+export const Player = styled.span<{ winner?: boolean }>`
+  width: 40%;
   text-align: center;
+  ${(props) => {
+    if (props.winner) return `font-weight: 600;`;
+  }}
 `;
 
 export const Versus = styled.span`
-  width: 20%;
+  width: 10%;
   text-align: center;
 `;
 
-export const Score = styled.span`
+export const ScoreBox = styled.div`
+  display: flex;
+  justify-content: center;
+  /* text-align: center; */
+`;
+
+export const Score = styled.span<{ winner?: boolean; blue?: boolean; red?: boolean }>`
+  width: 40%;
   text-align: center;
+  ${(props) => {
+    if (props.winner) return `font-weight: 600;`;
+  }}
+  ${(props) => {
+    if (props.blue) return `color: ${lightBlue};`;
+    if (props.red) return `color: ${lightRed};`;
+  }}
 `;
 
 /*

--- a/src/components/leftSide/style.tsx
+++ b/src/components/leftSide/style.tsx
@@ -44,6 +44,7 @@ export const ProfileImg = styled.img<{ me: boolean }>`
 
 export const InfoWrapper = styled.div`
   display: flex;
+  flex-wrap: wrap;
 `;
 
 export const InfoLabel = styled.span`
@@ -58,19 +59,40 @@ export const InfoValue = styled.span`
 `;
 
 /*
+ *      Badge
+ */
+
+export const BadgeBox = styled.div`
+  display: flex;
+  gap: 10px;
+  padding-left: 5px;
+`;
+
+export const BadgeSet = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  align-items: center;
+`;
+
+export const BadgeImg = styled.img`
+  width: 35px;
+  border-radius: 50%;
+`;
+
+/*
  *      Game History
  */
 
 export const HistoryList = styled.ul`
-  /* height: 400px; */
-  flex: 1 0 auto;
+  /* max-height: 300px; */
+  /* flex: 1 0 auto; */
   overflow: auto;
 `;
 
 export const HistoryItem = styled.li`
   display: flex;
   flex-direction: column;
-  list-type: none;
 `;
 
 export const Players = styled.div`


### PR DESCRIPTION
## 개요
- 프로필 업적배지 추가 및 히스토리 업데이트

## 작업사항
- 프로필에 업적 추가
- 업적에 따른 배지 이미지 api 및 UI 구현
- 히스토리 필요한 데이터 추가 요청 및 재명명 (score, rule)
- 히스토리 스타일 구현
- 로그아웃 시 URL로 생성한 blob URL들 revoke

## 변경로직
- 로그아웃 버튼 컴포넌트화
- 프로필의 버튼 컴포넌트 3개 디렉토리로 분리

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
