### PR TITLE
fix: 2차인증에서 번호 변경 시 토글 바로 off되는 에러 #129

### DIFF
--- a/src/components/leftSide/UserSetting.tsx
+++ b/src/components/leftSide/UserSetting.tsx
@@ -48,7 +48,7 @@ export default function UserSetting({ handleClose }: PropType) {
 
   function handleToggle() {
     if (isToggleOn) {
-      authenticated ? onOpen() : setIsToggleOn(false);
+      statusOf2faQuery?.data.status ? onOpen() : setIsToggleOn(false);
     } else setIsToggleOn(true);
   }
 


### PR DESCRIPTION
## 개요
- 2차 인증이 이미 활성화된 사용자가 번호 변경 버튼을 클릭한 후
토글 클릭 시 확인 모달이 뜨지 않고 바로 토글 off됨

## 작업사항
- `handleToggle()` 조건으로 state 대신 쿼리데이터 결과로 수정

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
