### PR TITLE
fix: 프로필 클릭할 때마다 히스토리 순서 변경되는 에러 #137

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -3,6 +3,7 @@ import axios, { AxiosError } from "axios";
 export async function getProfile(username: string) {
   try {
     const res = await axios.get(`/user/profile/${username}`);
+    if (res.data.data.user.gameHistory) res.data.data.user.gameHistory.reverse();
     return res.data;
   } catch (err: unknown) {
     if (err instanceof AxiosError && err.response) {

--- a/src/components/leftSide/ProfileData.tsx
+++ b/src/components/leftSide/ProfileData.tsx
@@ -78,7 +78,7 @@ export function ProfileData({ user }: UserProfileProps) {
       <AchievementBadge achivements={user?.achievement} username={user?.username} />
       <S.InfoLabel>히스토리</S.InfoLabel>
       <S.HistoryList>
-        {user?.gameHistory.reverse().map((game) => {
+        {user?.gameHistory.map((game) => {
           return (
             <S.HistoryItem key={game.id}>
               <S.Rule>


### PR DESCRIPTION
## 개요
- 프로필 클릭할 때마다 히스토리 순서 변경되는 에러

## 작업사항
- api 반환 직전에 `reverse()` 하고 렌더링부 코드의 `reverse()` 삭제

## 코멘트
서버가 닫혀서 확인은 못해봤지만..

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- (예시) feat: 로그인 토큰 발행 기능 추가 -->
